### PR TITLE
Add sympy client exit timeout

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -33,7 +33,7 @@ const context = await esbuild.context({
 		"@lezer/lr",
 		...builtins],
 	format: "cjs",
-	target: "es2021",
+	target: "es2022",
 	platform: "node",
 	logLevel: "info",
 	sourcemap: prod ? false : "inline",

--- a/main.ts
+++ b/main.ts
@@ -103,7 +103,7 @@ export default class LatexMathPlugin extends Plugin {
     }
 
     onunload() {
-        this.sympy_evaluator.shutdown();
+        this.sympy_evaluator.shutdown(LatexMathPlugin.SYMPY_CLIENT_SHUTDOWN_TIMEOUT);
     }
 
     async loadSettings() {
@@ -116,6 +116,7 @@ export default class LatexMathPlugin extends Plugin {
 
     private static readonly ERR_NOTICE_TIMEOUT = 30 * 1000;
     private static readonly ERR_NOTICE_LINE_COUNT = 8;
+    private static readonly SYMPY_CLIENT_SHUTDOWN_TIMEOUT = 30;
 
     private sympy_evaluator: SympyServer;
     private spawn_sympy_client_promise: Promise<void>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES2021",
+    "target": "ES2022",
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
@@ -16,7 +16,7 @@
       "ES5",
       "ES6",
       "ES7",
-      "ES2021"
+      "ES2022"
     ],
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
The sympy client is now force killed if it has not gracefully shutdown within 30 seconds.