### PR TITLE
Upper case greek letters

### DIFF
--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/greek_symbols.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/greek_symbols.lark
@@ -1,27 +1,42 @@
 // Based on sympy's original greek_symbols.lark: https://github.com/sympy/sympy/blob/2e7baea39cd0d891433bdc2ef2222e445c381ca3/sympy/parsing/latex/lark/grammar/greek_symbols.lark
 
-ALPHA: "\\alpha"
-BETA: "\\beta"
-GAMMA: "\\gamma"
-DELTA: "\\delta"
-EPSILON: "\\epsilon" |  "\\varepsilon"
-ZETA: "\\zeta"
-ETA: "\\eta"
-THETA: "\\theta" | "\\vartheta"
-IOTA: "\\iota"
-KAPPA: "\\kappa"
-LAMBDA: "\\lambda"
-MU: "\\mu"
-NU: "\\nu"
-XI: "\\xi"
-RHO: "\\rho" | "\\varrho"
-SIGMA: "\\sigma"
-TAU: "\\tau"
-UPSILON: "\\upsilon"
-PHI: "\\phi" | "\\varphi"
-CHI: "\\chi"
-PSI: "\\psi"
-OMEGA: "\\omega"
+ALPHA_LOWER: "\\alpha"
+BETA_LOWER: "\\beta"
+GAMMA_LOWER: "\\gamma"
+DELTA_LOWER: "\\delta"
+EPSILON_LOWER: "\\epsilon" | "\\varepsilon"
+ZETA_LOWER: "\\zeta"
+ETA_LOWER: "\\eta"
+THETA_LOWER: "\\theta" | "\\vartheta"
+IOTA_LOWER: "\\iota"
+KAPPA_LOWER: "\\kappa"
+LAMBDA_LOWER: "\\lambda"
+MU_LOWER: "\\mu"
+NU_LOWER: "\\nu"
+XI_LOWER: "\\xi"
+RHO_LOWER: "\\rho" | "\\varrho"
+SIGMA_LOWER: "\\sigma"
+TAU_LOWER: "\\tau"
+UPSILON_LOWER: "\\upsilon"
+PHI_LOWER: "\\phi" | "\\varphi"
+CHI_LOWER: "\\chi"
+PSI_LOWER: "\\psi"
+OMEGA_LOWER: "\\omega"
 
-GREEK_SYMBOL: ALPHA | BETA | GAMMA | DELTA | EPSILON | ZETA | ETA | THETA | IOTA | KAPPA
-    | LAMBDA | MU | NU | XI | RHO | SIGMA | TAU | UPSILON | PHI | CHI | PSI | OMEGA
+GAMMA_UPPER: "\\Gamma"
+DELTA_UPPER: "\\Delta"
+THETA_UPPER: "\\Theta"
+LAMBDA_UPPER: "\\Lambda"
+XI_UPPER: "\\Xi"
+SIGMA_UPPER: "\\Sigma"
+UPSILON_UPPER: "\\Upsilon"
+PHI_UPPER: "\\Phi" | "\\varPhi"
+PSI_UPPER: "\\Psi"
+OMEGA_UPPER: "\\Omega"
+
+GREEK_SYMBOL_LOWER: ALPHA_LOWER | BETA_LOWER | GAMMA_LOWER | DELTA_LOWER | EPSILON_LOWER | ZETA_LOWER | ETA_LOWER | THETA_LOWER | IOTA_LOWER | KAPPA_LOWER
+    | LAMBDA_LOWER | MU_LOWER | NU_LOWER | XI_LOWER | RHO_LOWER | SIGMA_LOWER | TAU_LOWER | UPSILON_LOWER | PHI_LOWER | CHI_LOWER | PSI_LOWER | OMEGA_LOWER
+
+GREEK_SYMBOL_UPPER: GAMMA_UPPER | DELTA_UPPER | THETA_UPPER | LAMBDA_UPPER | XI_UPPER | SIGMA_UPPER | UPSILON_UPPER | PHI_UPPER | PSI_UPPER | OMEGA_UPPER
+
+GREEK_SYMBOL: GREEK_SYMBOL_LOWER | GREEK_SYMBOL_UPPER

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/latex_math_grammar.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/latex_math_grammar.lark
@@ -65,7 +65,8 @@ exponentiation_arg: basefactor_arg _CARET function_special_arg -> exponentiation
 // ======== Symbols ========
 
 substitute_symbol: combine_symbol
-combine_symbol: indexed_symbol | _non_indexed_symbol
+combine_symbol: delta_symbol | indexed_symbol | _non_indexed_symbol
+delta_symbol: DELTA_UPPER combine_symbol
 
 single_letter_symbol: SINGLE_LETTER_SYMBOL -> combine_symbol
 multi_letter_symbol: MULTI_LETTER_SYMBOL -> combine_symbol
@@ -99,7 +100,7 @@ _numeric_number: HEXADECIMAL_NUMBER | BASE_10_NUMBER | OCTAL_NUMBER | BINARY_NUM
 
 // ======== Functions ========
 
-undefined_function: UNDEFINED_FUNC_START list_of_expressions _R_PAREN
+undefined_function: [DELTA_UPPER] UNDEFINED_FUNC_START list_of_expressions _R_PAREN
 
 // groups all functions whic cannot be used as an argument to other functions.
 // to pass this type of function, delimit them so they are matched by the _delimited_factor rule.
@@ -606,6 +607,7 @@ OPERATOR_DIV: _CMD_DIV | DIV
 OPERATOR_MUL: MUL | _CMD_TIMES | _CMD_CDOT
 
 %import .greek_symbols.GREEK_SYMBOL
+%import .greek_symbols.DELTA_UPPER
 
 _PARTIAL_DIFFERENTIAL_SYMBOL: "\\partial"
 _UPRIGHT_DIFFERENTIAL_SYMBOL: "\\text{d}" | "\\mathrm{d}"

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
@@ -51,10 +51,16 @@ class DependenciesTransformer(UndefinedAtomsTransformer):
 
         return symbol_or_unit
 
-    def undefined_function(self, func_name: Token, func_args: Iterator[Expr]) -> Function | Expr:
+    def undefined_function(self, delta_token: Token | None, func_name: Token, func_args: Iterator[Expr]) -> Function | Expr:
         # include both the function itself, and all arguments to the function as dependencies.
         # e.g. f(x, 1, y) should produce [ 'f', 'x', 'y' ]
-        return [ Function(func_name.value[:-1]), *func_args ]
+
+        func_name = func_name.value[:-1]
+
+        if delta_token:
+            func_name = f"{delta_token.value} {func_name}"
+
+        return [ Function(func_name), *func_args ]
 
     @v_args(inline=False)
     def list_of_expressions(self, tokens: Iterator[Expr]) -> list[Expr]:

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/UndefinedAtomsTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/UndefinedAtomsTransformer.py
@@ -18,8 +18,11 @@ class UndefinedAtomsTransformer(Transformer):
     def __init__(self, definition_store: DefinitionStore):
         self.__definition_store = definition_store
 
-    def combine_symbol(self, *symbol_strings: str) -> Symbol:
+    def combine_symbol(self, *symbol_strings: str) -> str:
         return ''.join(map(str, symbol_strings))
+
+    def delta_symbol(self, delta_token: Token, symbol_string: str) -> str:
+        return self.combine_symbol(delta_token.value, ' ', symbol_string)
 
     def substitute_symbol(self, symbol_name: str) -> Symbol | Expr:
         definition = self.__definition_store.get_definition(str(symbol_name), default=SympyDefinition(Symbol(symbol_name)))
@@ -53,8 +56,12 @@ class UndefinedAtomsTransformer(Transformer):
         else:
             return self.substitute_symbol(unit_symbol)
 
-    def undefined_function(self, func_name: Token, func_args: Iterator[Expr]) -> Function | Expr:
+    def undefined_function(self, delta_token: Token | None, func_name: Token, func_args: Iterator[Expr]) -> Function | Expr:
         func_name = func_name.value[:-1] # remove the suffixed parenthesees
+
+        if delta_token:
+            func_name = f"{delta_token.value} {func_name}"
+
         func_definition = self.__definition_store.get_definition(func_name)
 
         if func_definition is not None and isinstance(func_definition, DefinitionStore.FunctionDefinition):

--- a/lmat-cas-client/tests/Parser_test.py
+++ b/lmat-cas-client/tests/Parser_test.py
@@ -238,6 +238,15 @@ class TestParse:
 
         assert result == s_a + s_b * s_c + sqrt(s_e**s_f) + s_d**-1
 
+    def test_delta_symbols(self):
+        delta_v = Symbol(r"\Delta v")
+        delta_f = Function(r"\Delta f")
+        x = Symbol('x')
+
+        result = self._parse_expr(r"\Delta   f(x) + \Delta v + \Delta       v")
+
+        assert result == delta_f(x) + 2 * delta_v
+
     def test_definitions(self):
         result = self._parse_expr(r"x", { "symbols": { "x": [ "real" ] } })
         assert result == symbols("x", real=True)


### PR DESCRIPTION
Adds all upper case greek variants (except for `\Delta`) as possible single letter symbols.

`\Delta` is reserved as a special prefix for functions and symbols requiting no formatting.

That is, in contrast to most other cases, `\Delta x` is seen as a single symbol, even though there is whitespace between them.

`\Delta x` and `\Delta     x` is also seen as the same symbol, that is the whitespace betwee the `\Delta` prefix and the symbol itself does not matter, it is always collapsed to a single space.