### PR TITLE
Undefine undefined variables fix

### DIFF
--- a/lmat-cas-client/lmat_cas_client/LmatEnvironment.py
+++ b/lmat-cas-client/lmat_cas_client/LmatEnvironment.py
@@ -60,7 +60,7 @@ class LmatEnvironment(BaseModel):
             match definition_id:
                 case Symbol() as def_symbol:
                     if definition.value_expr == "":
-                        del definitions[def_symbol.name]
+                        definitions.pop(def_symbol.name, None)
                     else:
                         definitions[def_symbol.name] = AstDefinition(
                             expr_transformer = sympy_transformer_runner,
@@ -69,7 +69,7 @@ class LmatEnvironment(BaseModel):
                         )
                 case AppliedUndef() as def_function:
                     if definition.value_expr == "":
-                        del definitions[def_function.name]
+                        definitions.pop(def_function.name, None)
                     else:
                         definitions[def_function.name] = AstFunctionDefinition(
                             expr_transformer = sympy_transformer_runner,

--- a/lmat-cas-client/tests/Evaluate_test.py
+++ b/lmat-cas-client/tests/Evaluate_test.py
@@ -26,31 +26,41 @@ class TestEvaluate:
 
         assert result.sympy_expr == 2
 
-
     def test_matrix_single_line(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({"expression": r"2 \cdot \begin{bmatrix} 1 \\ 1 \end{bmatrix}", "environment": {}})
+        result = handler.handle(
+            {
+                "expression": r"2 \cdot \begin{bmatrix} 1 \\ 1 \end{bmatrix}",
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 2 * Matrix([[1], [1]])
 
-
     def test_matrix_multi_line(self):
         handler = EvalHandler(self.compiler)
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         2
         \cdot
         \begin{bmatrix}
         1 & 2 \\
         3 & 4
         \end{bmatrix}
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 2 * Matrix([[1, 2], [3, 4]])
 
     def test_matrix_normal(self):
         handler = EvalHandler(self.compiler)
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         \Vert
         \begin{bmatrix}
         20 \\
@@ -59,13 +69,18 @@ class TestEvaluate:
         50
         \end{bmatrix}
         \Vert
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == sqrt(20**2 + 30**2 + 40**2 + 50**2)
 
     def test_matrix_inner_prodcut(self):
         handler = EvalHandler(self.compiler)
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         \langle
         \begin{bmatrix}
         1 \\
@@ -77,136 +92,175 @@ class TestEvaluate:
         4
         \end{bmatrix}
         \rangle
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 1 * 2 + 2 * 4
-
 
     def test_relational_evaluation(self):
         a, b = symbols("a b")
 
         handler = EvalHandler(self.compiler)
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         5 + 5 + 5 + 5 = 10 + 10
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 20
 
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         a = b = (a - b)^2
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
-        assert result.sympy_expr == (a - b)**2
+        assert result.sympy_expr == (a - b) ** 2
 
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
         1 = 2 = 1
-        """, "environment": {}})
+        """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 1
 
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
             \begin{cases}
             2 + 2 + 2 + 2 &= 4 + 2 + 2 \\
                           &= 4 + 4
             \end{cases}
-            """, "environment": {}})
+            """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 8
         assert result.expr_lines == (4, 4)
 
-        result = handler.handle({"expression": r"""
+        result = handler.handle(
+            {
+                "expression": r"""
             1 = 2 = 3 = 4 = 5 = 6 = 7 = 8 = 9
-            """, "environment": {}})
+            """,
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 9
-
 
     def test_variable_substitution(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({
-            "expression": r"a + b",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="a", value_expr="2"),
-                    EnvDefinition(name_expr="b", value_expr="3")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"a + b",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="a", value_expr="2"),
+                        EnvDefinition(name_expr="b", value_expr="3"),
+                    ]
+                },
             }
-        })
+        )
         assert result.sympy_expr == 5
 
-        result = handler.handle({
-            "expression": r"\alpha",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="\\alpha", value_expr="2")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"\alpha",
+                "environment": {
+                    "definitions": [EnvDefinition(name_expr="\\alpha", value_expr="2")]
+                },
             }
-        })
+        )
         assert result.sympy_expr == 2
 
-        result = handler.handle({
-            "expression": r"A^T B",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="A", value_expr=r"""
+        result = handler.handle(
+            {
+                "expression": r"A^T B",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(
+                            name_expr="A",
+                            value_expr=r"""
                     \begin{bmatrix}
                     1 \\ 2
                     \end{bmatrix}
-                    """),
-                    EnvDefinition(name_expr="B", value_expr=r"""
+                    """,
+                        ),
+                        EnvDefinition(
+                            name_expr="B",
+                            value_expr=r"""
                     \begin{bmatrix}
                     3 \\ 4
                     \end{bmatrix}
-                    """)
-                ]
+                    """,
+                        ),
+                    ]
+                },
             }
-        })
+        )
         assert result.sympy_expr == Matrix([11])
 
-        result = handler.handle({
-            "expression": r"\sin{abc}",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="abc", value_expr="1")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"\sin{abc}",
+                "environment": {
+                    "definitions": [EnvDefinition(name_expr="abc", value_expr="1")]
+                },
             }
-        })
+        )
         assert result.sympy_expr == sin(1)
 
-        result = handler.handle({
-            "expression": r"\sqrt{ val_{sub} + val_{2}^{val_{three}}}",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="val_{sub}", value_expr="7"),
-                    EnvDefinition(name_expr="val_{2}", value_expr="3"),
-                    EnvDefinition(name_expr="val_{three}", value_expr="2")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"\sqrt{ val_{sub} + val_{2}^{val_{three}}}",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="val_{sub}", value_expr="7"),
+                        EnvDefinition(name_expr="val_{2}", value_expr="3"),
+                        EnvDefinition(name_expr="val_{three}", value_expr="2"),
+                    ]
+                },
             }
-        })
+        )
         assert result.sympy_expr == 4
 
-        x = Symbol('x')
+        x = Symbol("x")
 
-        result = handler.handle({
-            "expression": "x",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="x", value_expr="25"),
-                    EnvDefinition(name_expr="x", value_expr=""),
-                ]
+        result = handler.handle(
+            {
+                "expression": "x",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="x", value_expr="25"),
+                        EnvDefinition(name_expr="x", value_expr=""),
+                    ]
+                },
             }
-        })
+        )
 
         assert result.sympy_expr == x
 
     def test_gradient(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({
-            "expression": r"\nabla (x^2 y + y^2 x)",
-            "environment": {}
-        })
+        result = handler.handle(
+            {"expression": r"\nabla (x^2 y + y^2 x)", "environment": {}}
+        )
 
         x, y = symbols("x y")
         assert result.sympy_expr == Matrix([y * (2 * x + y), x * (2 * y + x)])
@@ -224,19 +278,25 @@ class TestEvaluate:
 
     def test_factor(self):
         handler = FactorHandler(self.compiler)
-        result = handler.handle({"expression": "x^3 - 10x^2 + 3x + 54", "environment": {}})
+        result = handler.handle(
+            {"expression": "x^3 - 10x^2 + 3x + 54", "environment": {}}
+        )
         x = symbols("x")
         assert result.sympy_expr == (x - 9) * (x - 3) * (x + 2)
 
     def test_apart(self):
         handler = ApartHandler(self.compiler)
-        result = handler.handle({"expression": r"\frac{8x + 7}{x^2 + x - 2}", "environment": {}})
+        result = handler.handle(
+            {"expression": r"\frac{8x + 7}{x^2 + x - 2}", "environment": {}}
+        )
         x = symbols("x")
         assert result.sympy_expr == 3 / (x + 2) + 5 / (x - 1)
 
     def test_quick_derivative(self):
         handler = ExpandHandler(self.compiler)
-        result = handler.handle({"expression": "(x^5 + 3x^4 + 2x + 5)'''", "environment": {}})
+        result = handler.handle(
+            {"expression": "(x^5 + 3x^4 + 2x + 5)'''", "environment": {}}
+        )
         x = symbols("x")
         assert result.sympy_expr == 60 * x**2 + 72 * x
 
@@ -244,214 +304,278 @@ class TestEvaluate:
         handler = EvalHandler(self.compiler)
 
         # Standard function
-        result = handler.handle({
-            "expression": "f(25, -2)",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="f(x, y)", value_expr="2x + y^2 + C"),
-                    EnvDefinition(name_expr="C", value_expr="-4")
-                ]
+        result = handler.handle(
+            {
+                "expression": "f(25, -2)",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="f(x, y)", value_expr="2x + y^2 + C"),
+                        EnvDefinition(name_expr="C", value_expr="-4"),
+                    ]
+                },
             }
-        })
+        )
         assert result.sympy_expr == 50
 
         # Function with arg name defined as variables
-        result = handler.handle({
-            "expression": "f(y)",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="f(x)", value_expr="2x"),
-                    EnvDefinition(name_expr="x", value_expr="-1"),
-                    EnvDefinition(name_expr="y", value_expr="99")
-                ]
+        result = handler.handle(
+            {
+                "expression": "f(y)",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="f(x)", value_expr="2x"),
+                        EnvDefinition(name_expr="x", value_expr="-1"),
+                        EnvDefinition(name_expr="y", value_expr="99"),
+                    ]
+                },
             }
-        })
+        )
         assert result.sympy_expr == 198
 
         # Function with matrices as input
-        result = handler.handle({
-            "expression": r"f(\begin{bmatrix} 5 & 10 \end{bmatrix})",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="f(x)", value_expr="x x^T")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"f(\begin{bmatrix} 5 & 10 \end{bmatrix})",
+                "environment": {
+                    "definitions": [EnvDefinition(name_expr="f(x)", value_expr="x x^T")]
+                },
             }
-        })
+        )
         assert result.sympy_expr == Matrix([[125]])
 
     def test_hessian(self):
         handler = EvalHandler(self.compiler)
-        x, y = symbols('x y')
+        x, y = symbols("x y")
 
         # Standard function
-        result = handler.handle({
-            "expression": r"\mathbf{H}(y x^5 + \sin(y))",
-            "environment": {}
-        })
-        assert result.sympy_expr == Matrix([
-                                                [20 * x**3 * y,     5 * x ** 4],
-                                                [5 * x ** 4,        - sin(y)]
-                                                ])
+        result = handler.handle(
+            {"expression": r"\mathbf{H}(y x^5 + \sin(y))", "environment": {}}
+        )
+        assert result.sympy_expr == Matrix(
+            [[20 * x**3 * y, 5 * x**4], [5 * x**4, -sin(y)]]
+        )
 
-        result = handler.handle({
-            "expression": r"\mathbf{H}(f)",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="f(x, y, z)", value_expr=r"\log(x) + e^y")
-                ]
+        result = handler.handle(
+            {
+                "expression": r"\mathbf{H}(f)",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(
+                            name_expr="f(x, y, z)", value_expr=r"\log(x) + e^y"
+                        )
+                    ]
+                },
             }
-        })
+        )
 
-        assert result.sympy_expr == Matrix([
-            [- 1 / x**2,    0,      0],
-            [0,             E**y,   0],
-            [0,             0,      0]
-        ])
-
+        assert result.sympy_expr == Matrix([[-1 / x**2, 0, 0], [0, E**y, 0], [0, 0, 0]])
 
     def test_jacobi(self):
         handler = EvalHandler(self.compiler)
-        x, y = symbols('x y')
+        x, y = symbols("x y")
 
         # Standard function
-        result = handler.handle({
-            "expression": r"\mathbf{J}(\begin{bmatrix} x^2 \\ y \\ x * y \end{bmatrix})",
-            "environment": {}
-        })
-        assert result.sympy_expr == Matrix([
-            [2 * x, 0],
-            [0,     1],
-            [y,     x]
-        ])
-
-        result = handler.handle({
-            "expression": r"\mathbf{J}(f)",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(
-                    name_expr="f(x, y, z)",
-                    value_expr=r"\begin{bmatrix}\log(x)\\ \sin(y) \\ \cos(x) * \sin(y) \end{bmatrix}"
-                    )
-                ]
+        result = handler.handle(
+            {
+                "expression": r"\mathbf{J}(\begin{bmatrix} x^2 \\ y \\ x * y \end{bmatrix})",
+                "environment": {},
             }
-        })
+        )
+        assert result.sympy_expr == Matrix([[2 * x, 0], [0, 1], [y, x]])
 
-        assert result.sympy_expr == Matrix([
-            [1 / x,             0,              0],
-            [0,                 cos(y),         0],
-            [-sin(x) * sin(y),  cos(x) * cos(y),0]
-        ])
+        result = handler.handle(
+            {
+                "expression": r"\mathbf{J}(f)",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(
+                            name_expr="f(x, y, z)",
+                            value_expr=r"\begin{bmatrix}\log(x)\\ \sin(y) \\ \cos(x) * \sin(y) \end{bmatrix}",
+                        )
+                    ]
+                },
+            }
+        )
+
+        assert result.sympy_expr == Matrix(
+            [[1 / x, 0, 0], [0, cos(y), 0], [-sin(x) * sin(y), cos(x) * cos(y), 0]]
+        )
 
     def test_assumptions(self):
         handler = EvalHandler(self.compiler)
-        x = symbols('x', real=True)
-        result = handler.handle({ 'expression': r"\bar x x", 'environment': { 'symbols': {'x': ['real']} }})
+        x = symbols("x", real=True)
+        result = handler.handle(
+            {"expression": r"\bar x x", "environment": {"symbols": {"x": ["real"]}}}
+        )
         assert result.sympy_expr == x**2
 
     def test_combinatorial(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({ 'expression': r"P(10, 5)", 'environment': { } })
+        result = handler.handle({"expression": r"P(10, 5)", "environment": {}})
 
         assert result.sympy_expr == 30240
 
-        n, c = symbols('n C')
-        result = handler.handle({'expression': r"C (2 + 3) + C(n, 42)", 'environment': { } })
+        n, c = symbols("n C")
+        result = handler.handle(
+            {"expression": r"C (2 + 3) + C(n, 42)", "environment": {}}
+        )
 
         assert result.sympy_expr == c * 5 + binomial(n, 42)
 
-        result = handler.handle({'expression': r"D(6)", 'environment': { } })
+        result = handler.handle({"expression": r"D(6)", "environment": {}})
 
         assert result.sympy_expr == 265
 
-        result = handler.handle({'expression': r"{!6}", 'environment': { } })
+        result = handler.handle({"expression": r"{!6}", "environment": {}})
 
         assert result.sympy_expr == 265
 
     def test_gamma(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({ 'expression': r"\frac{6!}{e} - \frac{\gamma\left(6 + 1, -1\right)}{e}", 'environment': { } })
+        result = handler.handle(
+            {
+                "expression": r"\frac{6!}{e} - \frac{\gamma\left(6 + 1, -1\right)}{e}",
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == 265
 
-        result = handler.handle({ 'expression': r"\Gamma(25 + 1)", 'environment': { } })
+        result = handler.handle({"expression": r"\Gamma(25 + 1)", "environment": {}})
         assert result.sympy_expr == factorial(25)
 
-
-        result = handler.handle({ 'expression': r"\Gamma(4, 5)", 'environment': { } })
+        result = handler.handle({"expression": r"\Gamma(4, 5)", "environment": {}})
         assert result.sympy_expr == 236 / exp(5)
 
     def test_divisibility(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({ 'expression': r"{3 + 5^2} \mod 2", 'environment': { } })
+        result = handler.handle({"expression": r"{3 + 5^2} \mod 2", "environment": {}})
         assert result.sympy_expr == 0
 
-        a, b, m = symbols('a b m')
-        result = handler.handle({ 'expression': r"(a \mod m + b \mod m) \mod m", 'environment': { } })
+        a, b, m = symbols("a b m")
+        result = handler.handle(
+            {"expression": r"(a \mod m + b \mod m) \mod m", "environment": {}}
+        )
         assert result.sympy_expr == Mod(a + b, m)
 
-        result = handler.handle({ 'expression': r"\gcd(8, 12)", 'environment': { } })
+        result = handler.handle({"expression": r"\gcd(8, 12)", "environment": {}})
 
         assert result.sympy_expr == 4
 
-        result = handler.handle({ 'expression': r"\operatorname{lcm}(6, 21)", 'environment': { } })
+        result = handler.handle(
+            {"expression": r"\operatorname{lcm}(6, 21)", "environment": {}}
+        )
         assert result.sympy_expr == 42
 
     def test_complex(self):
         handler = EvalHandler(self.compiler)
 
-        result = handler.handle({ 'expression': r"\Re (5 + 7 i)", 'environment': { } })
+        result = handler.handle({"expression": r"\Re (5 + 7 i)", "environment": {}})
         assert result.sympy_expr == 5
 
-        result = handler.handle({ 'expression': r"\operatorname{Im} (5 + 7 i)", 'environment': { } })
+        result = handler.handle(
+            {"expression": r"\operatorname{Im} (5 + 7 i)", "environment": {}}
+        )
         assert result.sympy_expr == 7
 
-        result = handler.handle({ 'expression': r"\arg e^{i \pi / 2}", 'environment': { } })
-        assert result.sympy_expr == pi/2
+        result = handler.handle(
+            {"expression": r"\arg e^{i \pi / 2}", "environment": {}}
+        )
+        assert result.sympy_expr == pi / 2
 
-        result = handler.handle({ 'expression': r"\mathrm{sgn}(-256)", 'environment': { } })
+        result = handler.handle(
+            {"expression": r"\mathrm{sgn}(-256)", "environment": {}}
+        )
 
         assert result.sympy_expr == -1
 
     def test_taylor(self):
         handler = EvalHandler(self.compiler)
-        x, y, z = symbols('x y z')
+        x, y, z = symbols("x y z")
 
-        result = handler.handle({
-            'expression': r"T_{2,\sin{x},1}(x)",
-            "environment": {}
-        })
+        result = handler.handle(
+            {"expression": r"T_{2,\sin{x},1}(x)", "environment": {}}
+        )
 
+        assert result.sympy_expr == sin(1) + (x - 1) * cos(1) - Rational(1, 2) * (
+            x - 1
+        ) ** 2 * sin(1)
 
-        assert result.sympy_expr == sin(1) + (x - 1) * cos(1) - Rational(1, 2) *(x - 1)**2 * sin(1)
+        result = handler.handle(
+            {
+                "expression": r"T_{3,\sin{x} + \cos{y} + \tan{z}}(x, y, z)",
+                "environment": {},
+            }
+        )
 
-        result = handler.handle({
-            'expression': r"T_{3,\sin{x} + \cos{y} + \tan{z}}(x, y, z)",
-            "environment": {}
-        })
-
-        assert result.sympy_expr == 1 + x - Rational(1, 2) * y **2 + z - Rational(1, 6) * x ** 3 + Rational(1, 3) * z ** 3
+        assert (
+            result.sympy_expr
+            == 1
+            + x
+            - Rational(1, 2) * y**2
+            + z
+            - Rational(1, 6) * x**3
+            + Rational(1, 3) * z**3
+        )
 
         expr = sin(x) * cos(z) - tan(z) * sec(y)
 
-        result = handler.handle({
-            'expression': r"T_{2,\sin{x} \cos{z} - \tan{z} \sec{y},\begin{bmatrix} 1 \\ 2 \\ 3 \end{bmatrix}}(1, 2, 3)",
-            "environment": {}
-        })
+        result = handler.handle(
+            {
+                "expression": r"T_{2,\sin{x} \cos{z} - \tan{z} \sec{y},\begin{bmatrix} 1 \\ 2 \\ 3 \end{bmatrix}}(1, 2, 3)",
+                "environment": {},
+            }
+        )
 
         assert result.sympy_expr == expr.subs({x: 1, y: 2, z: 3})
 
-        result = handler.handle({
-            "expression": "T_{2,f}(x, y)",
-            "environment": {
-                "definitions": [
-                    EnvDefinition(name_expr="f(a, b)", value_expr=r"e^a + \sin b")
-                ]
+        result = handler.handle(
+            {
+                "expression": "T_{2,f}(x, y)",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="f(a, b)", value_expr=r"e^a + \sin b")
+                    ]
+                },
             }
-        })
+        )
 
         assert result.sympy_expr == 1 + x + y + x**2 / 2
 
     # TODO: add gradient test (it is already implicitly tested in test_jacobi so not high priority)
+
+    def test_regression_168(self):
+        handler = EvalHandler(self.compiler)
+
+        result = handler.handle(
+            {
+                "expression": "x",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="x", value_expr="1"),
+                        EnvDefinition(name_expr="x", value_expr=""),
+                        EnvDefinition(name_expr="x", value_expr=""),
+                    ]
+                },
+            }
+        )
+
+        assert result.sympy_expr == Symbol("x")
+
+        result = handler.handle(
+            {
+                "expression": "f",
+                "environment": {
+                    "definitions": [
+                        EnvDefinition(name_expr="f(x)", value_expr="x"),
+                        EnvDefinition(name_expr="f(x)", value_expr=""),
+                        EnvDefinition(name_expr="f(x)", value_expr=""),
+                    ]
+                },
+            }
+        )
+
+        assert result.sympy_expr == Symbol("f")


### PR DESCRIPTION
Fixes #168

Replaces a del call with a pop call, so if the key (the definition) is not present, it is ignored, instead of producing an error.