### PR TITLE
Ignore comments

### DIFF
--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/__init__.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/__init__.py
@@ -1,3 +1,3 @@
-from .PrettyParser import PrettyParserError
+from .Parser import PrettyParserError
 
 __all__ = [ "PrettyParserError" ]

--- a/lmat-cas-client/tests/Parser_test.py
+++ b/lmat-cas-client/tests/Parser_test.py
@@ -15,7 +15,22 @@ class TestParse:
 
     def _parse_expr(self, expr, environment: LmatEnvironment = {}) -> Expr:
         environment = LmatEnvironment.model_validate(environment)
-        return self.compiler.compile(expr, LmatEnvironment.create_definition_store(environment))
+        return self.compiler.compile(
+            expr, LmatEnvironment.create_definition_store(environment)
+        )
+
+    def test_comments(self):
+        result = self._parse_expr(
+            r"""
+1 + 1 % test comment %%% comment
+\cdot 50 \% % some more comments
+% this is an empty line
+\\\\\\\\\\\\\\%
+- 100 \ \%
+            """
+        )
+
+        assert result == 0.5
 
     def test_basic(self):
         a, b, c = symbols('a b c')


### PR DESCRIPTION
This PR renames the `PrettyParser` to simply `Parser` and adds pre processor functionality to this class.
A latex commendt remover pre-processor has been implemented as well for the latex parser.

fixes partially #161 