### PR TITLE
Remove non-whitespace requirement from function application

### DIFF
--- a/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
@@ -137,6 +137,7 @@ def lmat_env_to_definition_store(
     in the environment, compiling them, and chaining them into a singular
     definition store.
     """
+    env = LmatEnvironment.model_validate(env)
     stores = [StandardDefinitionStore]
 
     for definition_str in env.definitionsv2:

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
@@ -18,7 +18,7 @@ expression: (_align* (ADD|SUB))? term ((ADD|SUB) term)*
 term: implicit_multiplication ((OPERATOR_MUL|OPERATOR_CROSS|OPERATOR_DIV) (_align* (ADD|SUB))? implicit_multiplication)*
 
 // factors with no operator between them are implicitly multiplied together.
-?implicit_multiplication: _align* factor (_align* factor)* _align*
+implicit_multiplication: _align* factor (_align* factor)* _align*
 
 // a factor is either a number, a constant, a symbol, or a function.
 // here exponentiation, fractions, binomials are loosly seen as functions.
@@ -99,7 +99,13 @@ _numeric_number: HEXADECIMAL_NUMBER | BASE_10_NUMBER | OCTAL_NUMBER | BINARY_NUM
 
 // ======== Functions ========
 
-undefined_function: combine_symbol _UNDEF_FUNC_START list_of_expressions _R_PAREN
+// matches a potential function application, anything of the form,
+// f (x, y, ....)      where 'f' is some symbol.
+// if 'f' turns out to *not* be a symbol, this should just be interpreted as an implicit
+// multiplication between 'f' and the singular argument in its parameter list.
+// If there is more than one argument in its parameter list, a syntax error should be
+// raised
+maybe_function_application: combine_symbol (_L_PAREN list_of_expressions _R_PAREN | _L_BRACE _L_PAREN list_of_expressions _R_PAREN _R_BRACE)
 
 
 // groups all functions which cannot be used as an argument to other functions.
@@ -118,7 +124,7 @@ undefined_function: combine_symbol _UNDEF_FUNC_START list_of_expressions _R_PARE
     | _derivative
     | _postfix_function_arg
 
-?named_function: undefined_function
+?named_function: maybe_function_application
     | trig_function
     | _log
     | exponential
@@ -132,7 +138,7 @@ undefined_function: combine_symbol _UNDEF_FUNC_START list_of_expressions _R_PARE
 
 // matches a special kind of argument, defined by the fact that fractions and binomials can be passed without surrounding them with braces.
 substitute_single_letter_symbol.1: single_letter_symbol -> substitute_symbol
-?function_special_arg: braces_expression | parenthesees_expression | named_function | _delimited_function | frac | binom | substitute_single_letter_symbol | _digit
+?function_special_arg: braces_expression | frac | binom | substitute_single_letter_symbol | _digit
 
 
 // named functions
@@ -419,8 +425,6 @@ _L_BAR: _BAR
 %declare _R_BAR
 _L_DOUBLE_BAR: _DOUBLE_BAR
 %declare _R_DOUBLE_BAR
-
-_UNDEF_FUNC_START.1: /(?<! )(?<! \\left)\(/
 
 _L_DELIMITER: _DOT | _L_ANGLE | L_BRACE_LITERAL | _L_BRACKET | _L_CEIL | _L_FLOOR | _L_PAREN
 _R_DELIMITER: _DOT | _R_ANGLE | R_BRACE_LITERAL | _R_BRACKET | _R_CEIL | _R_FLOOR | _R_PAREN

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
@@ -51,7 +51,7 @@ class DependenciesTransformer(UndefinedAtomsTransformer):
                 assert False
 
     @override
-    def undefined_function(
+    def maybe_function_application(
         self, func_name: Symbol, func_args: Iterator[set[str]]
     ) -> set[str]:
         # include both the function itself, and all arguments to the function as dependencies.

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/CasExprTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/CasExprTransformer.py
@@ -12,6 +12,8 @@ from lmat_cas_client.compiling.transforming.cas_expr.ConstantsTransformer import
 )
 from lmat_cas_client.compiling.transforming.cas_expr.FunctionsTransformer import (
     BuiltInFunctionsTransformer,
+    ImplicitMulStrategy,
+    implicit_mul_strategy,
 )
 from lmat_cas_client.compiling.transforming.cas_expr.UndefinedAtomsTransformer import (
     UndefinedAtomsTransformer,
@@ -223,15 +225,18 @@ class CasExprTransformer(Transformer):
 
         return result
 
-    def implicit_multiplication(self, factors: list[Expr]) -> Expr:
-        result = S.One
+    @v_args(inline=True)
+    @implicit_mul_strategy(ImplicitMulStrategy.MULT)
+    def implicit_multiplication(self, *factors: Expr) -> Expr:
+        result = factors[0]
 
-        for token in factors:
-            result *= token
+        for factor in factors[1:]:
+            result *= factor
 
         return result
 
     @v_args(inline=True)
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def exponentiation(self, base: Expr, exponent: Expr) -> Expr:
         # special matrix notation.
         if isinstance(exponent, Symbol) and MatrixUtils.is_matrix(base):

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/FunctionsTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/FunctionsTransformer.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Optional
+from enum import Enum
+from typing import Any, Iterator, Optional
 
 import sympy
 from lark import Token, Transformer, v_args
@@ -6,11 +7,89 @@ from lmat_cas_client.compiling.definition.Resolver import (
     DefinitionResolver,
     FunctionResToken,
 )
+from lmat_cas_client.compiling.transforming.cas_expr.UndefinedAtomsTransformer import (
+    ImplicitMul,
+)
 from lmat_cas_client.math_lib import Functions, MatrixUtils
 from lmat_cas_client.math_lib.SymbolUtils import symbols_variable_order
 from sympy import *
 from sympy.core.function import UndefinedFunction
 from sympy.tensor.array import derive_by_array
+
+
+class ImplicitMulStrategy(Enum):
+    """
+    What strategy to use when an ImplicitMul class is recieved.
+    """
+
+    LHS = 0
+    """
+    Indicates the current rule handler should perform work
+    on the left hand side (lhs) of the implicit multiplication,
+    e.g. sin should use this, as the sin in \sin f(x) should be applied to
+    f and not (x)
+    """
+    RHS = 1
+    """
+    Like LHS, but indicate that the right hand side shoul be used
+    instead (rhs). e.g. f(x)! should use this, as ! should be applied
+    to (x) and not f.
+    """
+    MULT = 2
+    """
+    Indicate that the current rule handler should apply the implicit multiplication,
+    and then work with the result.
+    """
+
+
+def implicit_mul_strategy(strategy: ImplicitMulStrategy):
+    """
+    Use this decorator for any rule handlers which may receive ImplicitMul structs.
+    Depending on the chosen strategy, the relevant parts of ImplicitMul is automatically
+    passed to the rule handler, and an appropiate ImplicitMul object is constructed and
+    returned from the rule handlers result.
+    Note that at most 1 arg can be an ImplicitMul if the LHS or RHS strategy is picked.
+    """
+
+    def _decorator(handler):
+        def _wrapped(*args: Any):
+            new_args = []
+            had_failed_apply = False
+
+            # search for an ImplicitMul in args, if found
+            # substitute in lhs, rhs or implicit mul of both, depending on
+            # chosen strategy.
+            for arg in args:
+                match arg:
+                    case ImplicitMul(lhs, rhs):
+                        assert (
+                            not had_failed_apply or strategy == ImplicitMulStrategy.MULT
+                        )
+                        match strategy:
+                            case ImplicitMulStrategy.LHS:
+                                new_args.append(lhs)
+                            case ImplicitMulStrategy.RHS:
+                                new_args.append(rhs)
+                            case ImplicitMulStrategy.MULT:
+                                new_args.append(lhs * rhs)
+                        had_failed_apply = True
+                    case arg:
+                        new_args.append(arg)
+
+            # return result wrapped in an ImplicitMul for further bubbling up.
+            if had_failed_apply and strategy != ImplicitMulStrategy.MULT:
+                match strategy:
+                    case ImplicitMulStrategy.LHS:
+                        return ImplicitMul(handler(*new_args), rhs)
+                    case ImplicitMulStrategy.RHS:
+                        return ImplicitMul(lhs, handler(*new_args))
+            else:
+                # except if we aplied the ImplicitMul
+                return handler(*new_args)
+
+        return _wrapped
+
+    return _decorator
 
 
 @v_args(inline=True)
@@ -23,6 +102,7 @@ class BuiltInFunctionsTransformer(Transformer):
     def __init__(self, definition_resolver: DefinitionResolver):
         self.__definition_resolver = definition_resolver
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def trig_function(
         self, func_token: Token, exponent: Expr | None, arg: Expr
     ) -> Expr:
@@ -60,6 +140,7 @@ class BuiltInFunctionsTransformer(Transformer):
     def conjugate(self, arg: Expr) -> Expr:
         return conjugate(arg)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def log_implicit_base(
         self, func_token: Token, exponent: Expr | None, arg: Expr
     ) -> Expr:
@@ -73,25 +154,31 @@ class BuiltInFunctionsTransformer(Transformer):
 
         return self._try_raise_exponent(log_val, exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def log_explicit_base(
         self, _func_token: Token, base: Expr, exponent: Expr | None, arg: Expr
     ) -> Expr:
         return self._try_raise_exponent(log(arg, base), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def log_explicit_base_exponent_first(
         self, func_token: Token, exponent: Expr | None, base: Expr, arg: Expr
     ) -> Expr:
         return self.log_explicit_base(func_token, base, exponent, arg)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def exponential(self, exponent: Expr | None, arg: Expr) -> Expr:
         return self._try_raise_exponent(exp(arg), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def factorial(self, arg: Expr) -> Expr:
         return factorial(arg)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def percent(self, arg: Expr) -> Expr:
         return Mul(arg, 100**-1)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def permille(self, arg: Expr) -> Expr:
         return Mul(arg, 1000**-1)
 
@@ -101,6 +188,7 @@ class BuiltInFunctionsTransformer(Transformer):
     def lower_gamma(self, s: Expr, x: Expr) -> Expr:
         return lowergamma(s, x)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def limit(
         self, symbol: Expr, approach_value: Expr, direction: str | None, arg: Expr
     ) -> Expr:
@@ -108,21 +196,26 @@ class BuiltInFunctionsTransformer(Transformer):
         direction = "+-" if direction is None else direction
         return limit(arg, symbol, approach_value, direction)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def real_part(self, exponent: Expr | None, val: Expr) -> Expr:
         return self._try_raise_exponent(re(val), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def imaginary_part(self, exponent: Expr | None, val: Expr) -> Expr:
         return self._try_raise_exponent(im(val), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def argument(self, exponent: Expr | None, val: Expr) -> Expr:
         return self._try_raise_exponent(arg(val), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def sign(self, exponent: Expr | None, val: Expr) -> Expr:
         return self._try_raise_exponent(sign(val), exponent)
 
     def limit_direction(self, direction_token: Token) -> str:
         return direction_token.value
 
+    @implicit_mul_strategy(ImplicitMulStrategy.MULT)
     def abs(self, arg: Expr) -> Expr:
         # if arg is a matrix, this notation actually means taking its determinant.
         if MatrixUtils.is_matrix(arg):
@@ -179,6 +272,7 @@ class BuiltInFunctionsTransformer(Transformer):
             power, [(symbol, power if power is not None else 1)], expr
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def derivative_prime(self, expr: Expr, primes: Token):
         body, variables = self._expr_as_function(expr, range(0, 2))
 
@@ -258,29 +352,35 @@ class BuiltInFunctionsTransformer(Transformer):
             MatrixUtils.ensure_matrix(rhs), conjugate_convention="right"
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def determinant(self, exponent: Expr | None, mat: Expr) -> Expr:
         return self._try_raise_exponent(MatrixUtils.ensure_matrix(mat).det(), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def trace(self, exponent: Expr | None, mat: Expr) -> Expr:
         return self._try_raise_exponent(
             MatrixUtils.ensure_matrix(mat).trace(), exponent
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def adjugate(self, exponent: Expr | None, mat: Expr) -> Expr:
         return self._try_raise_exponent(
             MatrixUtils.ensure_matrix(mat).adjugate(), exponent
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def rref(self, exponent: Expr | None, mat: Expr) -> Expr:
         return self._try_raise_exponent(
             MatrixUtils.ensure_matrix(mat).rref()[0], exponent
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def unitvec(self, exponent: Expr | None, vector: Expr) -> Expr:
         return self._try_raise_exponent(
             MatrixUtils.ensure_matrix(vector).normalized(), exponent
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.RHS)
     def exp_transpose(self, mat: Expr, exponent: Token) -> Expr:
         exponents_str = exponent.value
         exponents_str = (
@@ -306,16 +406,19 @@ class BuiltInFunctionsTransformer(Transformer):
 
     # Linear Alg Specific Implementations
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def gradient(self, exponent: Expr | None, expr: Expr) -> Expr:
         body, variables = self._expr_as_function(expr)
         return self._try_raise_exponent(
             Matrix(derive_by_array(body, variables)), exponent
         )
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def hessian(self, exponent: Expr | None, expr: Expr) -> Expr:
         body, variables = self._expr_as_function(expr)
         return self._try_raise_exponent(hessian(body, variables), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def jacobian(self, exponent: Expr | None, expr: Expr) -> Expr:
         body, variables = self._expr_as_function(expr)
         matrix = MatrixUtils.ensure_matrix(body)
@@ -333,6 +436,7 @@ class BuiltInFunctionsTransformer(Transformer):
 
         return self._try_raise_exponent(Matrix.vstack(*gradients), exponent)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.LHS)
     def taylor(self, degree: Expr, expr: Expr, exp_point: Expr | None, *args: Expr):
         degree = simplify(degree)
 
@@ -387,6 +491,7 @@ class BuiltInFunctionsTransformer(Transformer):
     def lcm(self, a: Expr, b: Expr) -> Expr:
         return lcm(a, b)
 
+    @implicit_mul_strategy(ImplicitMulStrategy.MULT)
     def modulo(self, a: Expr, b: Expr) -> Expr:
         return Mod(a, b)
 

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/UndefinedAtomsTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/UndefinedAtomsTransformer.py
@@ -1,5 +1,7 @@
+from ctypes import ArgumentError
 from typing import Iterator
 
+from attr import frozen
 from lark import Token, Transformer, v_args
 from lmat_cas_client.compiling.definition.DefinitionStore import (
     SymbolDefinition,
@@ -11,8 +13,39 @@ from lmat_cas_client.compiling.definition.Resolver import (
     SymbolResToken,
 )
 from lmat_cas_client.math_lib.units import UnitUtils
-from sympy import Expr, Function, Number, Symbol
+from sympy import Expr, Number, Symbol
 from sympy.physics.units import Quantity
+
+
+@frozen
+class ImplicitMul:
+    """
+    This is needed for when a maybe_function_application rule does *not* apply the function,
+    then the expression should be interpreted as an implicit multiplication between the
+    function head and body.
+    However, this needs to happen at a higher level scope, so we need this special class
+    to represent this, and then only higher up in the implicit_multiplication handler,
+    actually perform the implicit multiplication.
+
+    An example of where this is problematic can be seen here:
+
+    \sin f (x)
+
+    *if* f is a function, then this should be interpreted as
+
+    \sin(f(x))
+
+    *if* f is NOT a function, then this should be interpreted as
+
+    \sin(f) * x
+
+    The parser currently parses this as the first case,
+    but this transformer injects this class when f is not a function,
+    so we can bubble up to the second case in the rule handlers.
+    """
+
+    lhs: Expr
+    rhs: Expr
 
 
 @v_args(inline=True)
@@ -72,13 +105,25 @@ class UndefinedAtomsTransformer(Transformer):
         else:
             return self.substitute_symbol(unit_symbol)
 
-    def undefined_function(
+    def maybe_function_application(
         self, func_head: Symbol, func_args: Iterator[Expr] = None
-    ) -> Function | Expr:
+    ) -> Expr | ImplicitMul:
         match self.__definition_store.get_resolver_token(func_head.name):
             case FunctionResToken() as token:
                 return self.__definition_store.resolve_applied(
                     token, map(lambda a: SymbolDefinition(SympyDef(a)), func_args)
                 )
             case _:
-                return Function(func_head.name)(*func_args)
+                # if it is not a defined function,
+                # we must interpret it as an implicit multiplication between func_head and func_args,
+                # IF func_args only contains 1 parameter, otherwise what the user has written, does not make sense,
+                # you cannot have an implicit multiplication between a symbol, and a function argument list.
+                if len(func_args) != 1:
+                    raise ArgumentError(
+                        f"Cannot multiply symbol {func_head} with argument list ({','.join(map(str, func_args))})!"
+                        f"\nIf you want {func_head} to be an undefined function, place a function assumption somewhere above this function."
+                        "\ne.g."
+                        f"\n${func_head}(x, y, ...) \\mapsto \\mathbb{{C}}$"
+                    )
+
+                return ImplicitMul(self.substitute_symbol(func_head), func_args[0])

--- a/lmat-cas-client/tests/Compiler_test.py
+++ b/lmat-cas-client/tests/Compiler_test.py
@@ -183,8 +183,10 @@ class TestLatexToCasExprCompiler:
         f, x = symbols("f x")
 
         assert self._parse_single_expr("f (x)") == f * x
-        assert self._parse_single_expr("f(x)") == Function("f")(x)
-        assert self._parse_single_expr(r"f\left(x\right)") == Function("f")(x)
+        assert self._parse_single_expr("f(x)") == f * x
+        assert self._parse_single_expr(
+            r"f\left(x\right)", {"definitionsv2": [r"f(x) \mapsto C"]}
+        ) == Function("f", complex=True)(x)
         assert self._parse_single_expr(r"f   \left(x\right)") == f * x
 
     def test_partial_relations(self):
@@ -286,10 +288,13 @@ class TestLatexToCasExprCompiler:
 
     def test_delta_symbols(self):
         delta_v = Symbol(r"\Delta{v}")
-        delta_f = Function(r"\Delta{f}")
+        delta_f = Function(r"\Delta{f}", real=True)
         x = Symbol("x")
 
-        result = self._parse_single_expr(r"\Delta   f(x) + \Delta v + \Delta       v")
+        result = self._parse_single_expr(
+            r"\Delta   f(x) + \Delta v + \Delta       v",
+            {"definitionsv2": ["\Delta  f(x) \mapsto R"]},
+        )
 
         assert result == delta_f(x) + 2 * delta_v
 
@@ -519,12 +524,17 @@ class TestLatexToCasExprCompiler:
         )
     )
 
+    def _assert_compiles_to(self, latex: str, expected_expr: Expr) -> None:
+        assert simplify(self._parse_single_expr(latex).doit()) == simplify(
+            expected_expr
+        )
+
     @pytest.mark.parametrize(
         "latex,expected_expr",
         derivative_test_cases + partial_derivative_test_cases,
     )
     def test_physics_derivative(self, latex, expected_expr):
-        assert self._parse_single_expr(latex) == simplify(expected_expr)
+        self._assert_compiles_to(latex, expected_expr)
 
     @pytest.mark.parametrize(
         "latex,expected_expr",
@@ -534,7 +544,39 @@ class TestLatexToCasExprCompiler:
         ],
     )
     def test_regression_192(self, latex, expected_expr):
-        assert self._parse_single_expr(latex) == simplify(expected_expr)
+        self._assert_compiles_to(latex, expected_expr)
+
+    @pytest.mark.parametrize(
+        "latex,expected_expr",
+        [
+            (r"\sin f(x)", sympify("sin(f) * x")),
+            (r"\log g(y + z)", sympify("log(g) * (y + z)")),
+            (r"\log_5 g(y + z)", sympify("log(g, 5) * (y + z)")),
+            (r"\exp h(x^2)", sympify("exp(h) * x^2")),
+            (
+                r"f(6)! - gee(3)\% + h(1)\textperthousand",
+                sympify("720 * f - 0.03 * gee + 0.001 * h"),
+            ),
+            (
+                r"\lim_{x \to 5} f(x)",
+                Limit(S("f"), S("x"), 5) * S("x"),
+            ),
+            (
+                r"\Re f(x) + \Im f(x) + \arg f(x) + \operatorname{sgn} f(x)",
+                (re(S("f")) + im(S("f")) + arg(S("f")) + sign(S("f"))) * S("x"),
+            ),
+            (r"f(x^2)'", sympify("f * 2 * x")),
+            (r"\sum_{x=0}^5 f(x)", sympify("f * 15")),
+            (r"f(\begin{matrix} 1 & 0 \end{matrix})^T", S("f") * Matrix([1, 0])),
+            #
+            (r"f(g(h(j(x))))", sympify("f * g * h * j * x")),
+            (r"\Re g(\sin f(x)^2)!", re(S("g")) * factorial(sin(S("f")) * S("x") ** 2)),
+        ],
+    )
+    def test_maybe_applied_implicit_multiplication(
+        self, latex: str, expected_expr: Expr
+    ):
+        self._assert_compiles_to(latex, expected_expr)
 
 
 class TestLatexToLogicCompiler:

--- a/lmat-cas-client/tests/tests_sympy/test_latex_lark.py
+++ b/lmat-cas-client/tests/tests_sympy/test_latex_lark.py
@@ -5,8 +5,12 @@
 # This is here to ensure feature parity(ish) with their latex parser.
 # some tests have been slightly modified or disabled, due to fundamental differences in the parsers functionality (multi letter symbols is an exmaple of this)
 
-from lmat_cas_client.compiling.Compiler import LatexToCasExprCompiler
-from lmat_cas_client.math_lib.StandardDefinitionStore import StandardDefinitionStore
+from lmat_cas_client.compiling.Compiler import (
+    LatexToCasExprCompiler,
+    LatexToDefStoreCompiler,
+    lmat_env_to_definition_store,
+)
+from lmat_cas_client.LmatEnvironment import LmatEnvironment
 from sympy import (
     Add,
     Expr,
@@ -90,10 +94,12 @@ def _MatMul(a, b):
     return MatMul(a, b, evaluate=False)
 
 
-def parse_latex_lark(latex_str):
+def parse_latex_lark(latex_str, lmat_env: LmatEnvironment = {}):
     return (
         LatexToCasExprCompiler()
-        .compile(latex_str, StandardDefinitionStore)
+        .compile(
+            latex_str, lmat_env_to_definition_store(lmat_env, LatexToDefStoreCompiler())
+        )
         .get_expr(-1)
     )
 
@@ -296,22 +302,36 @@ INTEGRAL_EXPRESSION_PAIRS = [
 ]
 
 DERIVATIVE_EXPRESSION_PAIRS = [
-    (r"\frac{\dd}{\dd x} x", Derivative(x, x)),
-    (r"\frac{\differential}{\partial x} x", Derivative(x, x)),
-    (r"\frac{\partial}{\differential t} x", Derivative(x, t)),
-    (r"\frac{\dd}{\dd x^2} x^3", Derivative(x**3, (x, 2))),
-    (r"\frac{\dd x y}{\dd x \dd y}", Derivative(x * y, (x, 1), (y, 1))),
-    (r"\frac{\dd}{\dd x} ( \tan x )", Derivative(tan(x), x)),
-    (r"\frac{\dd f(x)}{\dd x}", Derivative(f(x), x)),
-    (r"\frac{\dd\theta(x)}{\dd x}", Derivative(Function(r"\theta")(x), x)),
-    (r"\frac{\dd[3]\theta(x)}{\dd x^3}", Derivative(Function(r"\theta")(x), x, x, x)),
+    (r"\frac{\dd}{\dd x} x", Derivative(x, x), {}),
+    (r"\frac{\differential}{\partial x} x", Derivative(x, x), {}),
+    (r"\frac{\partial}{\differential t} x", Derivative(x, t), {}),
+    (r"\frac{\dd}{\dd x^2} x^3", Derivative(x**3, (x, 2)), {}),
+    (r"\frac{\dd x y}{\dd x \dd y}", Derivative(x * y, (x, 1), (y, 1)), {}),
+    (r"\frac{\dd}{\dd x} ( \tan x )", Derivative(tan(x), x), {}),
+    (
+        r"\frac{\dd f(x)}{\dd x}",
+        Derivative(Function("f", real=True)(x), x),
+        {"definitionsv2": [r"f(x) \mapsto R"]},
+    ),
+    (
+        r"\frac{\dd\theta(x)}{\dd x}",
+        Derivative(Function(r"\theta", real=True)(x), x),
+        {"definitionsv2": [r"\theta(x) \mapsto R"]},
+    ),
+    (
+        r"\frac{\dd[3]\theta(x)}{\dd x^3}",
+        Derivative(Function(r"\theta", real=True)(x), x, x, x),
+        {"definitionsv2": [r"\theta(x) \mapsto R"]},
+    ),
     (
         r"\frac{\partial^3\theta(x)}{\dd x^3}",
-        Derivative(Function(r"\theta")(x), x, x, x),
+        Derivative(Function(r"\theta", real=True)(x), x, x, x),
+        {"definitionsv2": [r"\theta(x) \mapsto R"]},
     ),
     (
         r"\frac{\dd[2]\theta(x) \cdot y}{\dd x \dd y}",
-        Derivative(Function(r"\theta")(x) * y, x, y),
+        Derivative(Function(r"\theta", real=True)(x) * y, x, y),
+        {"definitionsv2": [r"\theta(x) \mapsto R"]},
     ),
 ]
 
@@ -380,14 +400,38 @@ UNEVALUATED_PRODUCT_EXPRESSION_PAIRS = [
 ]
 
 APPLIED_FUNCTION_EXPRESSION_PAIRS = [
-    (r"f(x)", f(x)),
-    (r"f(x, y)", f(x, y)),
-    (r"f(x, y, z)", f(x, y, z)),
-    (r"f'_1(x)", Function("f_{1}'")(x)),
-    (r"f_{1}''(x+y)", Function("f_{1}''")(x + y)),
+    (
+        r"f(x)",
+        Function("f", integer=True)(x),
+        {"definitionsv2": [r"f(x) \mapsto Z"]},
+    ),
+    (
+        r"f(x, y)",
+        Function("f", real=True)(x, y),
+        {"definitionsv2": [r"f(x, y) \mapsto R"]},
+    ),
+    (
+        r"f(x, y, z)",
+        Function("f", complex=True)(x, y, z),
+        {"definitionsv2": [r"f(x, y, z) \mapsto C"]},
+    ),
+    (
+        r"f'_1(x)",
+        Function("f_{1}'", real=True)(x),
+        {"definitionsv2": [r"f_{1}'(x) \mapsto R"]},
+    ),
+    (
+        r"f_{1}''(x+y)",
+        Function("f_{1}''", real=True)(x + y),
+        {"definitionsv2": [r"f_{1}''(x) \mapsto R"]},
+    ),
     (
         r"h_{\theta}(x_0, x_1)",
-        Function("h_{\\theta}")(Symbol("x_{0}"), Symbol("x_{1}")),
+        Function("h_{\\theta}", real=True)(
+            Symbol("x_{0}"),
+            Symbol("x_{1}"),
+        ),
+        {"definitionsv2": [r"h_{\theta}(x, y) \mapsto R"]},
     ),
 ]
 
@@ -632,10 +676,10 @@ def test_integral_expressions():
 
 def test_derivative_expressions():
     expected_failures = {5, 6}
-    for i, (latex_str, sympy_expr) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
+    for i, (latex_str, sympy_expr, lmat_env) in enumerate(DERIVATIVE_EXPRESSION_PAIRS):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == simplify(sympy_expr), latex_str
+        assert parse_latex_lark(latex_str, lmat_env) == simplify(sympy_expr), latex_str
 
 
 def test_trigonometric_expressions():
@@ -677,10 +721,12 @@ def test_applied_function_expressions():
         4,
     }  # 0 is ambiguous, and the others require not-yet-added features
     # not sure why 1, and 2 are failing
-    for i, (latex_str, sympy_expr) in enumerate(APPLIED_FUNCTION_EXPRESSION_PAIRS):
+    for i, (latex_str, sympy_expr, lmat_env) in enumerate(
+        APPLIED_FUNCTION_EXPRESSION_PAIRS
+    ):
         if i in expected_failures:
             continue
-        assert parse_latex_lark(latex_str) == simplify(sympy_expr), latex_str
+        assert parse_latex_lark(latex_str, lmat_env) == simplify(sympy_expr), latex_str
 
 
 def test_common_function_expressions():


### PR DESCRIPTION
Functions are no longer required to have no whitespace between the function head and their parameter list.
Function presence is now instead determined by user written function assumptions / definitions.