### PR TITLE
Fix partial derivative of defined functions

### DIFF
--- a/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
@@ -152,7 +152,6 @@ class LatexToCasExprCompiler(CasExprCompiler):
         """
         ast = cas_expr_parser.parse(latex_str)
 
-        print(ast.pretty(), flush=True)
         dependencies = dependencies_transformer_runner.transform(ast)
 
         assert_acyclic_dependencies(def_store, dependencies)

--- a/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/Compiler.py
@@ -152,6 +152,7 @@ class LatexToCasExprCompiler(CasExprCompiler):
         """
         ast = cas_expr_parser.parse(latex_str)
 
+        print(ast.pretty(), flush=True)
         dependencies = dependencies_transformer_runner.transform(ast)
 
         assert_acyclic_dependencies(def_store, dependencies)

--- a/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStore.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStore.py
@@ -5,7 +5,7 @@ from typing import MutableMapping
 
 from attr import field, frozen
 from lark import Tree
-from sympy import Basic
+from sympy import Basic, Expr
 from sympy.core.function import UndefinedFunction
 
 
@@ -21,14 +21,17 @@ class AstDef:
 
 @frozen
 class SympyDef:
-    """Definition entry for values defined as singular sympy expressions."""
+    """
+    Definition entry for values defined as singular sympy expressions.
+    """
 
     expr: Basic
 
 
 @frozen
 class AstFunDef:
-    """Like AstDef but for an applyable function with a body and an uneavluated value.
+    """
+    Like AstDef but for an appliable function with a body and an uneavluated value.
     e.g. f(x) = x^2
           ^      ^
         unappl.  |
@@ -37,6 +40,15 @@ class AstFunDef:
 
     body: Tree
     unapplied: Basic
+
+
+@frozen
+class SympyFunDef:
+    """
+    Like AstFunDef but for sympy Expr objects, instead of Lark trees.
+    """
+
+    body: Expr
 
 
 @frozen
@@ -49,7 +61,7 @@ type SymDefVal = AstDef | SympyDef
 UnionType representing all symbol-like definitions definable in a DefinitionStore
 """
 
-type FunDefVal = AstFunDef | SympyUndefFunDef
+type FunDefVal = AstFunDef | SympyFunDef | SympyUndefFunDef
 """
 UnionType representing all function-like definitions definable in a DefinitionStore
 """
@@ -61,7 +73,7 @@ class Definition(ABC):
     Base "class" for all types storable in a DefinitionStore.
     All definitions must hold a set of dependencies they must need to be resolved,
     before their own value can be safely resolved.
-    Note that extending this class, also requires implementing / extending and already existing Resolver,
+    Note that extending this class, also requires implementing / extending an already existing Resolver,
     for the definition to be resolvable.
     """
 

--- a/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStoreResolver.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStoreResolver.py
@@ -4,7 +4,7 @@ from typing import Any, MutableMapping, Optional, cast, override
 
 from lmat_cas_client.compiling.transforming.cas_expr.CasExprTransformer import CasExpr
 from lmat_cas_client.compiling.transforming.TransformerRunner import TransformerRunner
-from sympy import Basic, Symbol
+from sympy import Basic, Expr, Symbol
 
 from .DefinitionStore import (
     AstDef,
@@ -15,6 +15,7 @@ from .DefinitionStore import (
     FunctionDefinition,
     SymbolDefinition,
     SympyDef,
+    SympyFunDef,
     SympyUndefFunDef,
 )
 from .Resolver import (
@@ -58,7 +59,7 @@ class DefinitionStoreResolver(DefinitionResolver):
             return None
 
         # split SymbolDefinition and FunctionDefinition into 2 distinct ResolverToken's
-        match self._combined_store[def_id]:
+        match self.get_definition(def_id):
             case SymbolDefinition():
                 return SymbolResToken(def_id)
             case FunctionDefinition():
@@ -69,24 +70,33 @@ class DefinitionStoreResolver(DefinitionResolver):
                 assert False
 
     @override
-    def resolve_value(self, token: SymbolResToken):
+    def get_definition(self, def_id: str):
+        if def_id not in self._combined_store:
+            return None
+
+        return self._combined_store[def_id]
+
+    @override
+    def resolve_value(self, target: SymbolResToken | SymbolDefinition):
         # verify token is correct
-        match token:
+        cache_key = None
+        match target:
             case SymbolResToken(def_id):
+                # check cache
+                cache_key = def_id
+
+                if self._is_cached(cache_key, id=def_id):
+                    return self._cache[cache_key]
+
+                symbol_definition: SymbolDefinition = cast(
+                    SymbolDefinition, self._combined_store[def_id]
+                )
+            case SymbolDefinition() as symbol_definition:
                 pass
             case _:
                 assert False, "Token is not of the correct type"
 
-        # check cache
-        cache_key = def_id
-
-        if self._is_cached(cache_key, id=def_id):
-            return self._cache[cache_key]
-
         # resolve value
-        symbol_definition: SymbolDefinition = cast(
-            SymbolDefinition, self._combined_store[def_id]
-        )
 
         match symbol_definition.value:
             case SympyDef(expr):
@@ -98,21 +108,22 @@ class DefinitionStoreResolver(DefinitionResolver):
                 assert False, "Failed to resolve value"
 
     @override
-    def resolve_body(self, token: FunctionResToken):
-        match token:
+    def resolve_body(self, target: FunctionResToken | FunctionDefinition):
+        cache_key = None
+        match target:
             case FunctionResToken(def_id):
+                cache_key = def_id
+
+                if self._is_cached(cache_key, id=def_id):
+                    return self._cache[cache_key]
+
+                function_definition: FunctionDefinition = cast(
+                    FunctionDefinition, self._combined_store[def_id]
+                )
+            case FunctionDefinition() as function_definition:
                 pass
             case _:
                 assert False, "Token is not of the correct type"
-
-        cache_key = def_id
-
-        if self._is_cached(cache_key, id=def_id):
-            return self._cache[cache_key]
-
-        function_definition: FunctionDefinition = cast(
-            FunctionDefinition, self._combined_store[def_id]
-        )
 
         match function_definition.value:
             case AstFunDef(body_ast, _):
@@ -120,67 +131,76 @@ class DefinitionStoreResolver(DefinitionResolver):
                     body_ast, self._override_args({})
                 )
                 return self._cached(cas_expr.get_expr(-1), key=cache_key, id=def_id)
+            case SympyFunDef(body):
+                return body
             case SympyUndefFunDef(fun):
                 # Undefined function's body is exactly the same as its applied value,
                 # except its arguments are just its parameters.
-                return fun(*self.resolve_params(token))
+                return fun(*self.resolve_params(target))
             case _:
                 assert False, "Failed to resolve body"
 
     @override
-    def resolve_params(self, token: FunctionResToken):
-        match token:
+    def resolve_params(self, target: FunctionResToken | FunctionDefinition):
+        match target:
             case FunctionResToken(def_id):
+                function_definition: FunctionDefinition = cast(
+                    FunctionDefinition, self._combined_store[def_id]
+                )
+            case FunctionDefinition() as function_definition:
                 pass
             case _:
                 assert False, "Token is not of the correct type"
 
-        function_definition: FunctionDefinition = cast(
-            FunctionDefinition, self._combined_store[def_id]
-        )
         return tuple(map(lambda s: Symbol(s), function_definition.params))
 
     @override
-    def resolve_unapplied(self, token: FunctionResToken):
-        match token:
+    def resolve_unapplied(self, target: FunctionResToken | FunctionDefinition):
+        match target:
             case FunctionResToken(def_id):
+                # resolve_unapplied is uncached for now.
+                # not realy a reason to cache currently.
+
+                function_definition: FunctionDefinition = cast(
+                    FunctionDefinition, self._combined_store[def_id]
+                )
+            case FunctionDefinition() as function_definition:
                 pass
             case _:
                 assert False, "Token is not of the correct type"
-
-        # resolve_unapplied is uncached for now.
-        # not realy a reason to cache currently.
-
-        function_definition: FunctionDefinition = cast(
-            FunctionDefinition, self._combined_store[def_id]
-        )
 
         match function_definition.value:
             case AstFunDef(_, unapplied):
                 return unapplied
+            # TODO: what should SympyFunDef be here?
             case SympyUndefFunDef(fun):
                 return fun
             case _:
                 assert False, "Failed to resolve body"
 
     @override
-    def resolve_applied(self, token: FunctionResToken, arguments: Iterable[Definition]):
-        match token:
+    def resolve_applied(
+        self,
+        target: FunctionResToken | FunctionDefinition,
+        arguments: Iterable[Definition],
+    ):
+        arguments = tuple(arguments)
+        cache_key = None
+
+        match target:
             case FunctionResToken(def_id):
+                cache_key = (def_id, arguments)
+
+                if self._is_cached(cache_key, id=def_id):
+                    return self._cache[cache_key]
+
+                function_definition: FunctionDefinition = cast(
+                    FunctionDefinition, self._combined_store[def_id]
+                )
+            case FunctionDefinition() as function_definition:
                 pass
             case _:
                 assert False, "Token is not of the correct type"
-
-        arguments = tuple(arguments)
-
-        cache_key = (def_id, arguments)
-
-        if self._is_cached(cache_key, id=def_id):
-            return self._cache[cache_key]
-
-        function_definition: FunctionDefinition = cast(
-            FunctionDefinition, self._combined_store[def_id]
-        )
 
         if len(function_definition.params) != len(arguments):
             raise ValueError(
@@ -194,6 +214,23 @@ class DefinitionStoreResolver(DefinitionResolver):
             case AstFunDef(body_ast, _):
                 cas_expr = self._transformer.transform(body_ast, arg_resolver)
                 return self._cached(cas_expr.get_expr(-1), key=cache_key, id=def_id)
+            case SympyFunDef(body):
+                # subs the resolved parameters into the body Expr.
+                params = self.resolve_params(target)
+
+                subs_dict: dict[Basic | complex, Expr] = dict()
+
+                for param in params:
+                    param_token = arg_resolver.get_resolver_token(param.name)
+                    match param_token:
+                        case SymbolResToken():
+                            subs_dict[param] = arg_resolver.resolve_value(param_token)
+                        case FunctionResToken():
+                            subs_dict[param] = arg_resolver.resolve_unapplied(
+                                param_token
+                            )
+
+                return body.subs(subs_dict)
             case SympyUndefFunDef(fun):
                 # Create new resolver with arguments set to definition, then ask for the value
 
@@ -223,7 +260,7 @@ class DefinitionStoreResolver(DefinitionResolver):
             this is relevant for when to *not* cache the value.
         """
         try:
-            if id not in self._args_store:
+            if id not in self._args_store and key is not None:
                 self._cache[key] = value
         except TypeError:
             pass  # if key is unhashable, simply dont cache.

--- a/lmat-cas-client/lmat_cas_client/compiling/definition/EmptyResolver.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/definition/EmptyResolver.py
@@ -1,6 +1,10 @@
 from collections.abc import Iterable
 from typing import override
 
+from lmat_cas_client.compiling.definition.DefinitionStore import (
+    FunctionDefinition,
+    SymbolDefinition,
+)
 from lmat_cas_client.compiling.definition.Resolver import (
     Definition,
     DefinitionResolver,
@@ -16,27 +20,37 @@ class EmptyResolver(DefinitionResolver):
     """
 
     @override
-    def get_resolver_token(self, _name: str):
+    def get_resolver_token(self, _def_id: str):
         return None
 
     @override
-    def resolve_value(self, _token: SymbolResToken) -> Basic:
+    def get_definition(self, _def_id: str):
+        return None
+
+    @override
+    def resolve_value(self, _target: SymbolResToken | SymbolDefinition) -> Basic:
         raise NotImplementedError()
 
     @override
-    def resolve_body(self, _token: FunctionResToken) -> Basic:
+    def resolve_body(self, _target: FunctionResToken | FunctionDefinition) -> Basic:
         raise NotImplementedError()
 
     @override
-    def resolve_params(self, _token: FunctionResToken) -> tuple[Basic]:
+    def resolve_params(
+        self, _target: FunctionResToken | FunctionDefinition
+    ) -> tuple[Basic]:
         raise NotImplementedError()
 
     @override
-    def resolve_unapplied(self, _token: FunctionResToken) -> Basic:
+    def resolve_unapplied(
+        self, _target: FunctionResToken | FunctionDefinition
+    ) -> Basic:
         raise NotImplementedError()
 
     @override
     def resolve_applied(
-        self, _token: FunctionResToken, _params: Iterable[Definition]
+        self,
+        _target: FunctionResToken | FunctionDefinition,
+        _params: Iterable[Definition],
     ) -> Basic:
         raise NotImplementedError()

--- a/lmat-cas-client/lmat_cas_client/compiling/definition/Resolver.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/definition/Resolver.py
@@ -3,7 +3,11 @@ from collections.abc import Iterable
 from typing import Optional
 
 from attr import frozen
-from lmat_cas_client.compiling.definition.DefinitionStore import Definition
+from lmat_cas_client.compiling.definition.DefinitionStore import (
+    Definition,
+    FunctionDefinition,
+    SymbolDefinition,
+)
 from sympy import Basic
 
 
@@ -43,14 +47,25 @@ class DefinitionResolver(ABC):
         pass
 
     @abstractmethod
-    def resolve_value(self, token: SymbolResToken) -> Basic:
+    def get_definition(self, def_id: str) -> Optional[Definition]:
+        """
+        Retrieve the definition object associated with the given definition
+        id.
+        This can be supplied to all methods which a ResolverToken can be passed to,
+        do note that this means the resolver is then no longer aware of what id the Definition
+        is tied to, so any optional caching will not occur.
+        """
+        pass
+
+    @abstractmethod
+    def resolve_value(self, target: SymbolResToken | SymbolDefinition) -> Basic:
         """
         Resolve the value of a symbol definition.
         """
         pass
 
     @abstractmethod
-    def resolve_body(self, token: FunctionResToken) -> Basic:
+    def resolve_body(self, target: FunctionResToken | FunctionDefinition) -> Basic:
         """
         Resolve the body of a function definition.
         Parameters are simply seen as symbols when resolving the body value.
@@ -58,7 +73,9 @@ class DefinitionResolver(ABC):
         pass
 
     @abstractmethod
-    def resolve_params(self, token: FunctionResToken) -> tuple[Basic]:
+    def resolve_params(
+        self, target: FunctionResToken | FunctionDefinition
+    ) -> tuple[Basic]:
         """
         Resolve the parameters to a function definition.
         The parameters are returned as Sympy objects (most likely Symbol)
@@ -66,7 +83,7 @@ class DefinitionResolver(ABC):
         pass
 
     @abstractmethod
-    def resolve_unapplied(self, token: FunctionResToken) -> Basic:
+    def resolve_unapplied(self, target: FunctionResToken | FunctionDefinition) -> Basic:
         """
         Resolve the unapplied version of a function definition.
         i.e. the f in f(x) := ...
@@ -75,7 +92,9 @@ class DefinitionResolver(ABC):
 
     @abstractmethod
     def resolve_applied(
-        self, token: FunctionResToken, params: Iterable[Definition]
+        self,
+        target: FunctionResToken | FunctionDefinition,
+        params: Iterable[Definition],
     ) -> Basic:
         """
         Resolve the applied value of a function definition.

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/CasExprParser.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/CasExprParser.py
@@ -234,36 +234,6 @@ class CasExprPostLexer(PostLex):
                 item = item.update(f"{self._grammar_namespace}{item.type}")
 
             yield item
-        # buffer = []
-
-        # def filtered_iterator() -> Iterator[Token]:
-        #     for item in stream:
-        #         if (
-        #             self._namespace_regex is not None
-        #             and not self._namespace_regex.match(item.type)
-        #         ):
-        #             # instead of this, change the type here and then remove it later? probably?
-        #             # idk if this will work anyways, what is the strat even if it does not work?
-        #             # lets not think about that and just DO IT! >:(
-        #             buffer.append(item)
-        #         else:
-        #             if self._namespace_regex is not None:
-        #                 yield item.update(self._namespace_regex.sub(r"\1\2", item.type))
-        #             else:
-        #                 yield item
-
-        # processed = self._process_scope(filtered_iterator(), LexerScope(), None, None)
-
-        # for item in processed:
-        #     while len(buffer) > 0:
-        #         yield buffer.pop()
-
-        #     if item.type.startswith("_"):
-        #         item = item.update(f"_{self._grammar_namespace}{item.type[1:]}")
-        #     else:
-        #         item = item.update(f"{self._grammar_namespace}{item.type}")
-
-        #     yield item
 
     def _process_scope(
         self,

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
@@ -11,14 +11,17 @@ _rel_op: EQUAL | NOT_EQUAL | LT | LTE | GT | GTE
 _align: _ALIGN | _LATEX_NEWLINE
 relation: (_align* _rel_op)? expression (_rel_op expression)* (_rel_op _align*)?
 
+// the below 3 rules (expression, term and implicit_multiplication) are conditionally inlined,
+// as they all should do nothing to their child, if only 1 is present.
+
 // an expression is a sum of terms
-expression: (_align* (ADD|SUB))? term ((ADD|SUB) term)*
+?expression: (_align* (ADD|SUB))? term ((ADD|SUB) term)*
 
 // a term is a series of products of factors separated by product operators.
-term: implicit_multiplication ((OPERATOR_MUL|OPERATOR_CROSS|OPERATOR_DIV) (_align* (ADD|SUB))? implicit_multiplication)*
+?term: implicit_multiplication ((OPERATOR_MUL|OPERATOR_CROSS|OPERATOR_DIV) (_align* (ADD|SUB))? implicit_multiplication)*
 
 // factors with no operator between them are implicitly multiplied together.
-implicit_multiplication: _align* factor (_align* factor)* _align*
+?implicit_multiplication: _align* factor (_align* factor)* _align*
 
 // a factor is either a number, a constant, a symbol, or a function.
 // here exponentiation, fractions, binomials are loosly seen as functions.

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/DependenciesTransformer.py
@@ -68,8 +68,26 @@ class DependenciesTransformer(UndefinedAtomsTransformer):
         return set([func_name, *func_args])
 
     @v_args(inline=False)
-    def list_of_expressions(self, tokens: Iterable[set[Symbol]]) -> set[Symbol]:
-        return set(chain.from_iterable(tokens))
+    def list_of_expressions(
+        self, expr_deps: Iterable[Symbol | set[Symbol]]
+    ) -> set[Symbol]:
+        # convert single symbols into an iterable so chain.from_iterable can work with them.
+        # this happens when a symbol rule is the last rule in one of the expressions.
+        return set(
+            filter(
+                lambda s: isinstance(s, Symbol),
+                chain.from_iterable(
+                    (
+                        (
+                            expr_symbols
+                            if isinstance(expr_symbols, Iterable)
+                            else [expr_symbols]
+                        )
+                        for expr_symbols in expr_deps
+                    )
+                ),
+            )
+        )
 
 
 type DepsTransformer = TransformerRunner[[], set[str]]

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/CasExprTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/CasExprTransformer.py
@@ -114,6 +114,7 @@ class CasExprTransformer(Transformer):
         return Integer(int(binary_number_str, 2))
 
     @v_args(meta=True, inline=True)
+    @ir_strat()
     def cas_expression(
         self, meta: Meta, cas_expr: CasExpr | list[CasExpr] | Basic
     ) -> CasExpr:
@@ -137,8 +138,9 @@ class CasExprTransformer(Transformer):
     def sor_and_chain(self, relations: list[CasExpr]) -> CasExpr:
         return CasExpr.from_cas_exprs(relations)
 
-    @v_args(meta=True)
-    def relation(self, meta: Meta, tokens: list[Expr | Token]) -> CasExpr:
+    @v_args(meta=True, inline=True)
+    @ir_strat()
+    def relation(self, meta: Meta, *tokens: Expr | Token) -> CasExpr:
         if len(tokens) == 1:
             return CasExpr(tuple([(cast(Expr, tokens[0]), meta)]))
         # construct a list of relations which later will be used to construct
@@ -167,16 +169,18 @@ class CasExprTransformer(Transformer):
 
         return CasExpr(tuple((relation, meta) for relation in relations))
 
-    def expression(self, tokens: list[Expr | Token]) -> Expr:
+    @v_args(inline=True)
+    @ir_strat()
+    def expression(self, *tokens: Expr | Token) -> Expr:
         # construct a sum between the given sympy expressions,
         # with the sign that separates them in the tokens list.
 
-        signs = [self.SIGN_DICT[t.type] for t in tokens if isinstance(t, Token)]
+        signs = [self._SIGN_DICT[t.type] for t in tokens if isinstance(t, Token)]
         values = list(filter(lambda t: not isinstance(t, Token), tokens))
 
         # if no first sign was specified, it is implicitly '+'.
         if len(signs) < len(values):
-            signs.insert(0, self.SIGN_DICT["ADD"])
+            signs.insert(0, self._SIGN_DICT["ADD"])
 
         if len(signs) != len(values):
             raise RuntimeError(
@@ -194,7 +198,9 @@ class CasExprTransformer(Transformer):
 
         return result
 
-    def term(self, tokens: list[Expr | Token]) -> Expr:
+    @v_args(inline=True)
+    @ir_strat()
+    def term(self, *tokens: Expr | Token) -> Expr:
         # multiply / divide a series of factor together.
         # tokens is a list of sympy expressions, representing factors,
         # separated by a multiplication / division token.
@@ -210,7 +216,7 @@ class CasExprTransformer(Transformer):
             sign: Integer = S.One
 
             if isinstance(tokens[i], Token):
-                sign = self.SIGN_DICT[cast(Token, tokens[i]).type]
+                sign = self._SIGN_DICT[cast(Token, tokens[i]).type]
                 i += 1
 
             factor: Expr = cast(Expr, tokens[i])
@@ -250,6 +256,7 @@ class CasExprTransformer(Transformer):
         return pow(base, exponent)
 
     @v_args(inline=True)
+    @ir_strat()
     def matrix_body(self, *body: Expr | Token) -> list[list[Expr]]:
         return [
             list(cast(Iterator[Expr], row))
@@ -260,12 +267,14 @@ class CasExprTransformer(Transformer):
         ]
 
     @v_args(inline=True)
+    @ir_strat()
     def matrix(self, matrix_begin_cmd, matrix_body, matrix_end_cmd) -> LatexMatrix:
         return MutableLatexMatrix(
             matrix_body, env_begin=str(matrix_begin_cmd), env_end=str(matrix_end_cmd)
         )
 
     @v_args(inline=True)
+    @ir_strat()
     def array_matrix(
         self, matrix_begin_cmd, array_options, matrix_body, matrix_end_cmd
     ) -> LatexMatrix:
@@ -282,7 +291,12 @@ class CasExprTransformer(Transformer):
     def matrix_like_delim(self, _: Iterator[Token]):
         return self.Delim.MatDelim
 
-    SIGN_DICT = {"ADD": S.One, "SUB": S.NegativeOne}
+    @v_args(inline=True)
+    @ir_strat()
+    def list_of_expressions(self, *exprs: Expr) -> Iterable[Expr]:
+        return exprs
+
+    _SIGN_DICT = {"ADD": S.One, "SUB": S.NegativeOne}
 
     def _create_relation(self, left: Expr, right: Expr, relation_type: str) -> Rel:
         with evaluate(False):
@@ -303,11 +317,6 @@ class CasExprTransformer(Transformer):
                     raise RuntimeError(
                         f"Unknown relation type '{relation_type}' between {left} and {right}"
                     )
-
-    def list_of_expressions(self, tokens: Iterator[Expr]) -> list[Expr]:
-        return list(
-            filter(lambda x: not isinstance(x, Token) or x.type != "COMMA", tokens)
-        )
 
 
 def cas_expr_transformer(resolver: DefinitionResolver):

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/FunctionsTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/FunctionsTransformer.py
@@ -8,8 +8,10 @@ from lmat_cas_client.compiling.definition.Resolver import (
     FunctionResToken,
 )
 from lmat_cas_client.compiling.transforming.cas_expr.UndefinedAtomsTransformer import (
+    BodyStrat,
     LhsStrat,
     RhsStrat,
+    SymbolStrat,
 )
 from lmat_cas_client.compiling.transforming.Ir import ir_strat
 from lmat_cas_client.math_lib import Functions, MatrixUtils
@@ -203,15 +205,15 @@ class BuiltInFunctionsTransformer(Transformer):
     def min(self, args: Iterator[Expr]):
         return Min(*args)
 
-    @ir_strat()
-    def diff_symbol_exponent(self, symbol, exponent: Expr | None):
+    @ir_strat(symbol=SymbolStrat)
+    def diff_symbol_exponent(self, symbol: Symbol, exponent: Expr | None):
         return (symbol, 1 if exponent is None else exponent)
 
     @ir_strat()
     def diff_symbol_arg_list(self, *arg_list: tuple[Expr, Expr]):
         return [*arg_list]
 
-    @ir_strat()
+    @ir_strat(expr=BodyStrat)
     def derivative_symbols_first(
         self, power: Optional[Expr], symbols: Iterable[tuple[Symbol, int]], expr: Expr
     ):
@@ -224,13 +226,13 @@ class BuiltInFunctionsTransformer(Transformer):
 
         return diff(expr, *symbols)
 
-    @ir_strat()
+    @ir_strat(expr=BodyStrat)
     def derivative_func_first(
         self, power: Optional[Expr], expr: Expr, symbols: Iterable[tuple[Symbol, int]]
     ):
         return self.derivative_symbols_first(power, symbols, expr)
 
-    @ir_strat()
+    @ir_strat(expr=BodyStrat, symbol=SymbolStrat)
     def derivative_phys_symbols_first(
         self, power: Optional[Expr], symbol: Symbol, expr: Expr
     ):
@@ -238,7 +240,7 @@ class BuiltInFunctionsTransformer(Transformer):
             power, [(symbol, int(power) if power is not None else 1)], expr
         )
 
-    @ir_strat()
+    @ir_strat(expr=BodyStrat, symbol=SymbolStrat)
     def derivative_phys_func_first(
         self, power: Optional[Expr], expr: Expr, symbol: Symbol
     ):
@@ -246,7 +248,7 @@ class BuiltInFunctionsTransformer(Transformer):
             power, [(symbol, int(power) if power is not None else 1)], expr
         )
 
-    @ir_strat(expr=RhsStrat)
+    @ir_strat(expr=(RhsStrat, BodyStrat))
     def derivative_prime(self, expr: Expr, primes: Token):
         body, variables = self._expr_as_function(expr, range(0, 2))
 
@@ -615,7 +617,6 @@ class BuiltInFunctionsTransformer(Transformer):
 
         if not MatrixUtils.is_matrix(index_target):
             index_target = Matrix(index_target)
-        # index_target = Matrix(index_target)
 
         match indicies:
             case [row_index, col_index]:

--- a/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/UndefinedAtomsTransformer.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/transforming/cas_expr/UndefinedAtomsTransformer.py
@@ -5,8 +5,11 @@ from typing import ClassVar, List, cast, final, override
 from attr import frozen
 from lark import Token, Transformer, v_args
 from lmat_cas_client.compiling.definition.DefinitionStore import (
+    Definition,
+    FunctionDefinition,
     SymbolDefinition,
     SympyDef,
+    SympyFunDef,
 )
 from lmat_cas_client.compiling.definition.Resolver import (
     DefinitionResolver,
@@ -21,7 +24,7 @@ from lmat_cas_client.compiling.transforming.Ir import (
     ir_strat,
 )
 from lmat_cas_client.math_lib.units import UnitUtils
-from sympy import Expr, Number, Symbol
+from sympy import Basic, Expr, Number, Symbol
 from sympy.physics.units import Quantity
 
 
@@ -80,6 +83,78 @@ class SymbolIr(Ir, SymbolStrat, SubstituteStrat):
                 return Resolved(cast(Expr, self.resolver.resolve_unapplied(token)))
             case _:
                 return cast(Resolved[Expr], self.as_symbol())
+
+
+class AppliedStrat(ResolveStrategy):
+    """
+    Ir object has an applied value, which this resolves.
+    """
+
+    _resolve_method = "as_applied"
+
+    @abstractmethod
+    def as_applied(self) -> Resolved[Basic]:
+        pass
+
+
+class BodyStrat(ResolveStrategy):
+    """
+    Ir object has a function body, which this resolves
+    """
+
+    _resolve_method = "as_body"
+
+    @abstractmethod
+    def as_body(self) -> Resolved[Basic]:
+        pass
+
+
+@final
+@frozen
+class FuncIr(Ir, AppliedStrat, BodyStrat):
+    """
+    Ir of a function application.
+    Stores the arguments passed to the function,
+    as well as the function definition itself.
+
+    Args:
+        AppliedStrat: Resolve the function value when applied with the given arguments.
+        BodyStrat: Resolve the body of the function.
+    """
+
+    args: tuple[Definition, ...]
+    func_target: FunctionResToken | FunctionDefinition
+    resolver: DefinitionResolver
+
+    _default_strat = AppliedStrat
+
+    @override
+    def as_applied(self) -> Resolved[Basic]:
+        return Resolved(self.resolver.resolve_applied(self.func_target, self.args))
+
+    @override
+    def as_body(self) -> Resolved[Basic]:
+
+        match self.func_target:
+            case FunctionResToken(id):
+                definition = cast(FunctionDefinition, self.resolver.get_definition(id))
+            case FunctionDefinition() as definition:
+                pass
+            case _:
+                assert False
+
+        return Resolved(
+            self.resolver.resolve_body(self.func_target),
+            post_resolve=lambda r: FuncIr(
+                self.args,
+                FunctionDefinition(
+                    SympyFunDef(r),
+                    definition.params,
+                    deps=definition.deps,  # type: ignore[arg-type]
+                ),
+                self.resolver,
+            ),
+        )
 
 
 class LhsStrat(ResolveStrategy):
@@ -221,14 +296,18 @@ class UndefinedAtomsTransformer(Transformer):
     @ir_strat(func_head=SymbolStrat)
     def maybe_function_application(
         self, func_head: Symbol, func_args: List[Expr]
-    ) -> Expr | MultIr:
+    ) -> FuncIr | MultIr:
         match self.__resolver.get_resolver_token(func_head.name):
             case FunctionResToken() as token:
-                return cast(
-                    Expr,
-                    self.__resolver.resolve_applied(
-                        token, map(lambda a: SymbolDefinition(SympyDef(a)), func_args)
-                    ),
+                # if it is a defined function,
+                # we need to wrap it in an intermediate reprensentation object,
+                # in the case this is the child of a partial derivative (or similar) rule,
+                # which needs to *first* differentiate the body and *then* apply the arguments to the
+                # new body.
+                return FuncIr(
+                    tuple(map(lambda a: SymbolDefinition(SympyDef(a)), func_args)),
+                    token,
+                    self.__resolver,
                 )
             case _:
                 # if it is not a defined function,

--- a/lmat-cas-client/tests/Evaluate_test.py
+++ b/lmat-cas-client/tests/Evaluate_test.py
@@ -393,8 +393,13 @@ class TestEvaluate:
     def test_partial_derivative(self):
         handler = EvalHandler(self.expr_compiler, self.store_compiler)
         result = handler.handle({"expression": "\n\\dv{x} x\n", "environment": {}})
-
         assert result.sympy_expr == 1
+
+        result = handler.handle({
+            "expression": r"g(10)",
+            "environment": {"definitionsv2": [r"f(x) := x^2", r"g(x) := \dv{f(x)}{x}"]},
+        })
+        assert result.sympy_expr == 20
 
     def test_function(self):
         handler = EvalHandler(self.expr_compiler, self.store_compiler)

--- a/lmat-cas-client/tests/LatexToDefinitionsCompiler_test.py
+++ b/lmat-cas-client/tests/LatexToDefinitionsCompiler_test.py
@@ -179,9 +179,7 @@ class TestLatexToDefinitionCompiler:
         assert result["z"].value.expr == Symbol("z", prime=True)
 
     def test_function_def(self):
-        # TODO: remove space from f (
-        #                          ^ here
-        result = self.compiler.compile(r"f (x) := x^3")
+        result = self.compiler.compile(r"f(x) := x^3")
 
         assert len(result) == 1
         assert isinstance(result["f"], FunctionDefinition)

--- a/lmat-cas-client/tests/tests_sympy/test_latex_lark.py
+++ b/lmat-cas-client/tests/tests_sympy/test_latex_lark.py
@@ -721,8 +721,7 @@ def test_applied_function_expressions():
     expected_failures = {
         3,
         4,
-    }  # 0 is ambiguous, and the others require not-yet-added features
-    # not sure why 1, and 2 are failing
+    }
     for i, (latex_str, sympy_expr, lmat_env) in enumerate(
         APPLIED_FUNCTION_EXPRESSION_PAIRS
     ):


### PR DESCRIPTION
Currently, when a function application is part of a partial derivative (say `f(x) := x^2` and expr to evaluate is `\dv{f(10)}{x}`), the function is first applied, and *then* the result is differentiated.

That is

`\dv{f(10)}{x} => \dv{100}{x} => 0`

However, the expected result would be to *first* differentiate f, and then substitute 10 into the result.
`\dv{f(10)}{x} == (remember, x = 10) ==> \dv{x^2}{x} => 2x = (subs in x = 10) => 20`

This PR aims to implement the second order of evaluations, by introducing a new `FunctionIr`, which can delay the application of functions, such that all the derivative rule handlers can get to first differentiate any potential function, before their arguments are applied.

Do note that this PR only adds this evaluation order iff the *only* input to any derivative rule consists purely of a single function application.

that is `\dv{f(x) + g(x)}{x}` will still first apply f and g, before differentiating them.
