### PR TITLE
Add Windows 2022 and Mac OS 14 to the OS test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, windows-2022, macos-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Add more OS version's to ensure a wider variety of platforms work