### PR TITLE
\left \right align fix

### DIFF
--- a/lmat-cas-client/lmat_cas_client/LmatLatexPrinter.py
+++ b/lmat-cas-client/lmat_cas_client/LmatLatexPrinter.py
@@ -1,11 +1,12 @@
 import re as regex
 from functools import reduce
-from typing import cast, override
+from typing import Any, cast, override
 
 from sympy import *
+from sympy.core.function import AppliedUndef
 from sympy.logic.boolalg import BooleanFalse, BooleanTrue
 from sympy.physics.units import Quantity
-from sympy.printing.latex import LatexPrinter
+from sympy.printing.latex import LatexPrinter, accepted_latex_functions
 
 from lmat_cas_client.compiling.transforming.LatexMatrix import (
     ImmutableLatexMatrix,
@@ -93,6 +94,85 @@ class LmatLatexPrinter(LatexPrinter):
         ])
 
         return result
+
+    @override
+    def _print_Function(self, expr: Function, exp: Any = None) -> str:
+        r"""
+        copied directly from LatexPrinter, because some string literals need to be changed,
+        and they were not configurable.
+        """
+        func = expr.func.__name__
+        if hasattr(self, "_print_" + func) and not isinstance(expr, AppliedUndef):
+            return getattr(self, "_print_" + func)(expr, exp)
+        else:
+            args = [str(self._print(arg)) for arg in expr.args]
+            # How inverse trig functions should be displayed, formats are:
+            # abbreviated: asin, full: arcsin, power: sin^-1
+            inv_trig_style = self._settings["inv_trig_style"]
+            # If we are dealing with a power-style inverse trig function
+            inv_trig_power_case = False
+            # If it is applicable to fold the argument brackets
+            can_fold_brackets = (
+                self._settings["fold_func_brackets"]
+                and len(args) == 1
+                and not self._needs_function_brackets(expr.args[0])
+            )
+
+            inv_trig_table = [
+                "asin",
+                "acos",
+                "atan",
+                "acsc",
+                "asec",
+                "acot",
+                "asinh",
+                "acosh",
+                "atanh",
+                "acsch",
+                "asech",
+                "acoth",
+            ]
+
+            # If the function is an inverse trig function, handle the style
+            if func in inv_trig_table:
+                if inv_trig_style == "abbreviated":
+                    pass
+                elif inv_trig_style == "full":
+                    func = ("ar" if func[-1] == "h" else "arc") + func[1:]
+                elif inv_trig_style == "power":
+                    func = func[1:]
+                    inv_trig_power_case = True
+
+                    # Can never fold brackets if we're raised to a power
+                    if exp is not None:
+                        can_fold_brackets = False
+
+            if inv_trig_power_case:
+                if func in accepted_latex_functions:
+                    name = r"\%s^{-1}" % func
+                else:
+                    name = r"\operatorname{%s}^{-1}" % func
+            elif exp is not None:
+                func_tex = self._hprint_Function(func)
+                func_tex = self.parenthesize_super(func_tex)
+                name = r"%s^{%s}" % (func_tex, exp)
+            else:
+                name = self._hprint_Function(func)
+
+            if can_fold_brackets:
+                if func in accepted_latex_functions:
+                    # Wrap argument safely to avoid parse-time conflicts
+                    # with the function name itself
+                    name += r" {%s}"
+                else:
+                    name += r"%s"
+            else:
+                name += r"\left(%s \right)"  # this is the modified line
+
+            if inv_trig_power_case and exp is not None:
+                name += r"^{%s}" % exp
+
+            return name % ",".join(args)
 
     # split expr into 3 expr.
     # the first contains all constants in the passed expression,

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_expr.lark
@@ -108,7 +108,7 @@ _numeric_number: HEXADECIMAL_NUMBER | BASE_10_NUMBER | OCTAL_NUMBER | BINARY_NUM
 // multiplication between 'f' and the singular argument in its parameter list.
 // If there is more than one argument in its parameter list, a syntax error should be
 // raised
-maybe_function_application: _symbol (_L_PAREN list_of_expressions _R_PAREN | _L_BRACE _L_PAREN list_of_expressions _R_PAREN _R_BRACE)
+maybe_function_application: _symbol _L_PAREN list_of_expressions _R_PAREN
 
 
 // groups all functions which cannot be used as an argument to other functions.

--- a/lmat-cas-client/tests/Compiler_test.py
+++ b/lmat-cas-client/tests/Compiler_test.py
@@ -377,6 +377,8 @@ class TestLatexToCasExprCompiler:
 
         x, a, b = symbols("x a b")
 
+        assert self._parse_single_expr(r"x {atm}") == x * u.atm
+
         assert (
             self._parse_single_expr(r"{a + b}^2 + {s}^2") == u.second**2 + (a + b) ** 2
         )

--- a/lmat-cas-client/tests/LmatPrinter_test.py
+++ b/lmat-cas-client/tests/LmatPrinter_test.py
@@ -49,5 +49,11 @@ class TestLmatPrinter:
         latex_str = self.printer.doprint(latex_matrix)
         self._assert_str_equal(latex_str, r"\begin{matrix}1&2\\3&4\end{matrix}")
 
+    def test_functions(self):
+        x = symbols("x")
+        func_application = sin(x)
+        latex_str = self.printer.doprint(func_application)
+        self._assert_str_equal(latex_str, r"\sin\left(x\right)")
+
     def _assert_str_equal(self, expected, actual):
         assert "".join(expected.split()) == "".join(actual.split())

--- a/src/LatexMathPlugin.ts
+++ b/src/LatexMathPlugin.ts
@@ -16,7 +16,7 @@ import { ConfirmModal } from '/views/modals/ConfirmModal';
 import { SuccessResponseVerifier } from './services/ResponseVerifier';
 import { EvaluateMode } from '/models/cas/messages/EvaluateMessage';
 import { TruthTableFormat } from '/models/cas/messages/TruthTableMessage';
-import { mathjaxLoadLatexPackages } from './utils/MathJaxPackageLoader';
+import { mathjaxLoadLatexPackages, mathjaxLoadLatexPreamble } from './utils/MathJaxPackageLoader';
 
 interface LatexMathPluginSettings {
     dev_mode: boolean;
@@ -66,6 +66,13 @@ export default class LatexMathPlugin extends Plugin {
 
         // import latex packages
         await mathjaxLoadLatexPackages(["physics"]);
+        // fix some alignment issues with \left and \right
+        await mathjaxLoadLatexPreamble(`
+\\let\\originalleft\\left
+\\let\\originalright\\right
+\\renewcommand{\\left}{\\mathopen{}\\originalleft}
+\\renewcommand{\\right}[1]{\\originalright#1\\mathclose{}}
+`);
     }
 
     // sets up the given map of commands as obsidian commands.

--- a/src/utils/MathJaxPackageLoader.ts
+++ b/src/utils/MathJaxPackageLoader.ts
@@ -7,19 +7,22 @@ declare global {
 
 // load the given set of latex packages via. injecting `\require` strings into MathJax.
 export async function mathjaxLoadLatexPackages(latex_packages: string[]) {
-    await loadMathJax();
-    
-    for (const latex_package of latex_packages) {
-        const require_str = `\\require{${latex_package}}`;
 
-        if (MathJax.tex2chtml == undefined) {
-            MathJax.startup.ready = () => {
-                MathJax.startup.defaultReady();
-                MathJax.tex2chtml(require_str);
-            };
-        } else {
-            MathJax.tex2chtml(require_str);
-        }
+    for (const latex_package of latex_packages) {
+        mathjaxLoadLatexPreamble(`\\require{${latex_package}}`);
     }
 
+}
+
+export async function mathjaxLoadLatexPreamble(latex_preamble: string) {
+    await loadMathJax();
+
+    if (MathJax.tex2chtml == undefined) {
+        MathJax.startup.ready = () => {
+            MathJax.startup.defaultReady();
+            MathJax.tex2chtml(latex_preamble);
+        };
+    } else {
+        MathJax.tex2chtml(latex_preamble);
+    }
 }


### PR DESCRIPTION
This PR removes support for writing function applications as `f{(arg1, arg2, arg3, ...)}`, but in turn fixes the `\left, \right` alignment issues, which was the reason for writing function applications like this in the first place.

This also fixes symbols being unable to be implicitly multiplied with a brace delimited expression.