### PR TITLE
Fix params being substituted for definitions

### DIFF
--- a/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStoreResolver.py
+++ b/lmat-cas-client/lmat_cas_client/compiling/definition/DefinitionStoreResolver.py
@@ -128,7 +128,10 @@ class DefinitionStoreResolver(DefinitionResolver):
         match function_definition.value:
             case AstFunDef(body_ast, _):
                 cas_expr = self._transformer.transform(
-                    body_ast, self._override_args({})
+                    body_ast,
+                    self._override_args({
+                        p.name: EmptyDefinition() for p in self.resolve_params(target)
+                    }),
                 )
                 return self._cached(cas_expr.get_expr(-1), key=cache_key, id=def_id)
             case SympyFunDef(body):

--- a/lmat-cas-client/tests/Compiler_test.py
+++ b/lmat-cas-client/tests/Compiler_test.py
@@ -595,7 +595,12 @@ class TestLatexToCasExprCompiler:
             # Three-variable function
             (
                 r"\grad(f)",
-                {"definitionsv2": [r"f(x, y, z) := x^2 + y^2 + z^2"]},
+                {
+                    "definitionsv2": [
+                        r"f(x, y, z) := x^2 + y^2 + z^2",
+                        r"x := 25 \quad y \in \mathbb{R}",
+                    ]
+                },
                 Matrix([2 * Symbol("x"), 2 * Symbol("y"), 2 * Symbol("z")]),
             ),
             # Complex expression


### PR DESCRIPTION
This PR fixes function parameters being incorrectly substituted for definitions with the same name, when resolving the *body* of the function.