### PR TITLE
fix ruff dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest-cov~=6.2
 pytest-xdist~=3.8
 pandas~=2.2
 tabulate~=0.9
-ruff~=0.12
+ruff~=0.14.0 # TODO: upgrade to newer version
 mypy~=1.19


### PR DESCRIPTION
Ruff version is now restricted to be no greater than 0.14.x temporarily.
A newer version brings some more checks in, which the codebase currently fails on.
Most of it seems to be in the tests which i dont really care about, but some of it seems relevant.
A later PR will upgrade the ruff version + fix all of the codebase issues ruff flags.