### PR TITLE
Solve refac

### DIFF
--- a/lmat-cas-client/lmat_cas_client/LmatEnvironment.py
+++ b/lmat-cas-client/lmat_cas_client/LmatEnvironment.py
@@ -17,5 +17,3 @@ class LmatEnvironment(BaseModel):
     definitions: list[EnvDefinition] = Field(default_factory=list)
 
     unit_system: Optional[str] = None
-
-    solve_domain: Optional[str] = None

--- a/lmat-cas-client/lmat_cas_client/command_handlers/SolveHandler.py
+++ b/lmat-cas-client/lmat_cas_client/command_handlers/SolveHandler.py
@@ -11,13 +11,16 @@ from lmat_cas_client.compiling.Compiler import (
 )
 from lmat_cas_client.LmatEnvironment import LmatEnvironment
 from lmat_cas_client.LmatLatexPrinter import lmat_latex
-from lmat_cas_client.math_lib.SymbolUtils import symbols_variable_order
+from lmat_cas_client.math_lib.SymbolUtils import (
+    symbol_assumptions_set,
+    symbols_variable_order,
+)
 from lmat_cas_client.math_lib.units import UnitUtils
 
 from .CommandHandler import *
 
 
-def _split_matrix_eqs(equations: Iterable[Basic]) -> Generator[Basic]:
+def _split_matrix_eqs(equations: Iterable[Basic]) -> Generator[Basic, None, None]:
     """
     Split every matrix equation (matrix on lhs and rhs) into a series of equations,
     for each element in the matrices.
@@ -79,9 +82,12 @@ class SolveResult(CommandResult):
             isinstance(solutions_set, FiniteSet)
             and len(solutions_set) <= SolveResult.MAX_RELATIONAL_FINITE_SOLUTIONS
         ):
-            return CommandResult.result(
-                dict(solution_set=lmat_latex(solutions_set.as_relational(symbols)))
-            )
+            rel_sol_set = solutions_set.as_relational(symbols)
+
+            if rel_sol_set == false:
+                rel_sol_set = EmptySet
+
+            return CommandResult.result(dict(solution_set=lmat_latex(rel_sol_set)))
         else:
             return CommandResult.result(
                 dict(
@@ -119,14 +125,6 @@ class SolveHandler(CompilingCommandHandler):
         if len(free_symbols) == 0:
             raise HandlerError("Cannot solve equation if no free symbols are present.")
 
-        solve_domain = S.Complexes
-
-        if (
-            message.environment.solve_domain is not None
-            and message.environment.solve_domain.strip() != ""
-        ):
-            solve_domain = sympify(message.environment.solve_domain)
-
         symbols: list[Symbol | None] = [None] * len(message.symbols)
 
         for free_symbol in free_symbols:
@@ -137,15 +135,14 @@ class SolveHandler(CompilingCommandHandler):
         if None in symbols:
             raise HandlerError(f"No such symbols: {message.symbols}")
 
-        if (
-            len(equations) == 1 and len(symbols) == 1
-        ):  # these two should always have equal length.
-            solution_set = solveset(equations[0], symbols[0], domain=solve_domain)
-        else:
-            try:
-                solution_set = linsolve(equations, symbols)
-            except NonlinearError:
-                solution_set = nonlinsolve(equations, symbols)
+        match equations, symbols:
+            case [eq], [Symbol() as symb]:
+                solution_set = solveset(eq, symb, domain=symbol_assumptions_set(symb))
+            case _:
+                try:
+                    solution_set = linsolve(equations, symbols)
+                except NonlinearError:
+                    solution_set = nonlinsolve(equations, symbols)
 
         unit_system = message.environment.unit_system
 
@@ -165,6 +162,9 @@ class SolveHandler(CompilingCommandHandler):
                         for sol in solution_set.args
                     )
                 )
+
+        if solution_set == false:
+            solution_set = EmptySet
 
         return SolveResult(solution_set, symbols)
 

--- a/lmat-cas-client/lmat_cas_client/command_handlers/SolveHandler.py
+++ b/lmat-cas-client/lmat_cas_client/command_handlers/SolveHandler.py
@@ -1,7 +1,8 @@
-from typing import Any, cast, override
+from typing import Any, Generator, Iterable, cast, override
 
 from pydantic import BaseModel
 from sympy import *
+from sympy.core.relational import Relational
 from sympy.solvers.solveset import NonlinearError
 
 from lmat_cas_client.Client import HandlerError
@@ -14,6 +15,39 @@ from lmat_cas_client.math_lib.SymbolUtils import symbols_variable_order
 from lmat_cas_client.math_lib.units import UnitUtils
 
 from .CommandHandler import *
+
+
+def _split_matrix_eqs(equations: Iterable[Basic]) -> Generator[Basic]:
+    """
+    Split every matrix equation (matrix on lhs and rhs) into a series of equations,
+    for each element in the matrices.
+
+    Args:
+        equations (list[Basic])
+
+    Raises:
+        HandlerError
+
+    Yields:
+        Basic: new equations generated from equations arg.
+    """
+    for eq in equations:
+        match eq:
+            case Relational():
+                match cast(Any, eq.lhs), cast(Any, eq.rhs):
+                    case MatrixBase() as lhs_mat, MatrixBase() as rhs_mat:
+                        if lhs_mat.shape != rhs_mat.shape:
+                            raise HandlerError(
+                                f"Cannot solve equations with different matrix shapes!\nlhs was {lhs_mat.shape} rhs was {rhs_mat.shape}"
+                            )
+
+                        for row in range(lhs_mat.rows):
+                            for col in range(rhs_mat.cols):
+                                yield type(eq)(lhs_mat[row, col], rhs_mat[row, col])
+                    case _:
+                        yield eq
+            case _:
+                yield eq
 
 
 class SolveMessage(BaseModel):
@@ -70,9 +104,11 @@ class SolveHandler(CompilingCommandHandler):
         )
 
         equations = list(
-            self._cas_expr_compiler.compile(
-                message.expression, definition_store
-            ).get_all_expr()
+            _split_matrix_eqs(
+                self._cas_expr_compiler.compile(
+                    message.expression, definition_store
+                ).get_all_expr()
+            )
         )
 
         # get a list of free symbols, by combining all the equations individual free symbols.
@@ -93,9 +129,6 @@ class SolveHandler(CompilingCommandHandler):
 
         symbols: list[Symbol | None] = [None] * len(message.symbols)
 
-        if len(message.symbols) != len(equations):
-            raise HandlerError("Incorrect number of symbols provided.")
-
         for free_symbol in free_symbols:
             if str(free_symbol) in message.symbols:
                 symbol_index = message.symbols.index(str(free_symbol))
@@ -106,7 +139,7 @@ class SolveHandler(CompilingCommandHandler):
 
         if (
             len(equations) == 1 and len(symbols) == 1
-        ):  # these two should always have equal lenth.
+        ):  # these two should always have equal length.
             solution_set = solveset(equations[0], symbols[0], domain=solve_domain)
         else:
             try:
@@ -170,9 +203,11 @@ class SolveInfoHandler(CompilingCommandHandler):
             message.environment, self._def_store_compiler
         )
         equations = list(
-            self._cas_expr_compiler.compile(
-                message.expression, definition_store
-            ).get_all_expr()
+            _split_matrix_eqs(
+                self._cas_expr_compiler.compile(
+                    message.expression, definition_store
+                ).get_all_expr()
+            )
         )
 
         # time for a full symbols list, and a default symbols list maybe?

--- a/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_def.lark
+++ b/lmat-cas-client/lmat_cas_client/compiling/parsing/cas_def.lark
@@ -6,59 +6,6 @@
 %import .cas_expr.relation
 %import .cas_logic_expr.cas_logic_expression
 
-// what is the left hand side?
-// - symbol
-// - symbol + function arg list
-// i think that is it?
-
-// what is the right hand side?
-// - relation
-// - set? (for assumptions)
-
-// what is the separator
-// - := (definition)
-// - \stackrel{def}{=}
-// - \stackrel{\mathrm{def}}{=}
-// - \vcentcoloneq(q?)
-// - =: (for flipping stuff?)
-// - \in (assumptions)
-// - \mapsto (undefined function assumptions)
-
-// what is a definition expression?
-// let def_expr represent a singular definition rule, then multiple def_expr are added via. the following methods.
-//
-// whitespace command: <--- And all of this stuff last [ ]
-// def_expr \quad def_expr (x := 5 \quad y := 10)
-//
-// chained with logical and
-// def_expr \land def_expr (x := 5 \land y := 10)
-//
-// system of expressions environments:
-// \begin{cases}
-// x &:= 5 \\
-// y &:= 10 \\
-// \end{cases}
-
-
-// some definitions examples:
-// == DEFINING A VARIABLE ==  <--- Start Here [ ]
-// x := 5
-// f (x, y) := x^2
-// ^ ^
-// | |
-// Symbol
-//   |
-//   Function Arguments
-// 
-// == DEFINING ASSUMPTIONS ON A SYMBOL == <--- Then Here [ ]
-//
-// x \in R (assume x to be Real)
-// x, y, z \in \mathbbm{Z} (assume x, y and z to be integers).
-//
-// == DEFINE SYMBOL TO BE AN UNDEFINED FUNCTION == <--- And Finally Here [ ]
-// f (x, y, z) \mapsto \mathbbm{R} (the symbol 'f', should be interpreted as a function taking 3 arguments, x, y and z, and its output always being a part of the real numbers set)
-//
-
 cas_logic_expr_def: symbol_cas_logic_expr_def (_DEF_SPACE symbol_cas_logic_expr_def)* -> cas_expr_def
 
 cas_expr_def: _definition ((_PROP_OP_AND|_DEF_SPACE) _definition)*

--- a/lmat-cas-client/lmat_cas_client/math_lib/SymbolUtils.py
+++ b/lmat-cas-client/lmat_cas_client/math_lib/SymbolUtils.py
@@ -1,7 +1,18 @@
 from typing import Iterable
 
 import regex
-from sympy import Symbol
+from sympy import (
+    Complexes,
+    FiniteSet,
+    Integers,
+    Interval,
+    Rationals,
+    Reals,
+    Set,
+    Symbol,
+    oo,
+    true,
+)
 
 __FORMATTED_SYMBOL_REGEX = r"(?:\\[^{]*{\s*)?(%s)(?:\s*})?(\s*_{.*})?"
 __symbols_priority = [
@@ -36,3 +47,36 @@ def symbols_var_order_key(symb: Symbol):
 # because x, y and z are more often used as variables compared to a, b and c.
 def symbols_variable_order(symbols: Iterable[Symbol]) -> list[Symbol]:
     return sorted(symbols, key=symbols_var_order_key)
+
+
+def symbol_assumptions_set(symbol: Symbol) -> Set:
+    """
+    Map a symbol to a sympy Set, of which the symbol resides in.
+    This Set is intended to be restrictive'ish, but still represent one of the
+    main types of number sets.
+
+    The set is picked based on the Symbol's assumptions.
+
+    Args:
+        symbol (Symbol)
+
+    Returns:
+        Set
+    """
+    res: Set = Complexes
+    if symbol.is_real == true:
+        res = res.intersect(Reals)
+    if symbol.is_rational == true:
+        res = res.intersect(Rationals)
+    if symbol.is_positive == true:
+        res = res.intersect(Interval(0, oo))
+    if symbol.is_negative == true:
+        res = res.intersect(Interval(-oo, 0))
+    if symbol.is_nonzero == true:
+        res = FiniteSet(0).complement(res)
+    if symbol.is_integer == true:
+        res = res.intersect(Integers)
+    if symbol.is_imaginary == true:
+        res = res.intersect(Reals.complement(Complexes))
+
+    return res

--- a/lmat-cas-client/tests/Solve_test.py
+++ b/lmat-cas-client/tests/Solve_test.py
@@ -58,6 +58,33 @@ class TestSolve:
         assert result.solution == FiniteSet((0, 0), (1, Rational(3, 2)))
         assert result.symbols == [x, y]
 
+        result = handler.handle({
+            "expression": r"""
+                \begin{bmatrix}
+                3 & 2 & -1 \\
+                2 & -2 & 4 \\
+                2 & -1 & 2
+                \end{bmatrix}
+                \begin{bmatrix}
+                x \\
+                y \\
+                z
+                \end{bmatrix}
+                =
+                \begin{bmatrix}
+                1 \\
+                -2 \\
+                0
+                \end{bmatrix}
+
+                """,
+            "environment": {},
+            "symbols": ["x", "y", "z"],
+        })
+
+        assert result.solution == FiniteSet((1, -2, -2))
+        assert result.symbols == [x, y, z]
+
     def test_solve_multivariate(self):
         x, y, z = symbols("x y z")
 

--- a/lmat-cas-client/tests/Solve_test.py
+++ b/lmat-cas-client/tests/Solve_test.py
@@ -1,3 +1,4 @@
+import pytest
 import sympy.physics.units as u
 from lmat_cas_client.command_handlers.SolveHandler import *
 from lmat_cas_client.compiling.Compiler import (
@@ -11,18 +12,49 @@ class TestSolve:
     cas_expr_compiler = LatexToCasExprCompiler()
     def_store_compiler = LatexToDefStoreCompiler()
 
-    def test_solve_with_domain(self):
-        x = symbols("x")
-
+    @pytest.mark.parametrize(
+        "expr,solve_symbs,defs,exp_symbs,exp_sol",
+        [
+            (
+                "x^2-100 = 0",
+                ["x"],
+                [r"x \in R_{+}"],
+                [Symbol("x", real=True, positive=True)],
+                FiniteSet(10),
+            ),
+            (
+                r"(x - \pi)(x - 10)(x + \frac{1}{3}) = 0",
+                ["x"],
+                [r"x \in Q_{+}"],
+                [Symbol("x", rational=True, positive=True)],
+                FiniteSet(10),
+            ),
+            (
+                r"x^3 + 3x^2 - i x^2 - 3i x = 0",
+                ["x"],
+                [r"x \in I"],
+                [Symbol("x", imaginary=True)],
+                FiniteSet(I),
+            ),
+        ],
+    )
+    def test_solve_with_assumptions(
+        self,
+        expr: str,
+        solve_symbs: list[str],
+        defs: list[str],
+        exp_symbs: list[Symbol],
+        exp_sol: Set,
+    ):
         handler = SolveHandler(self.cas_expr_compiler, self.def_store_compiler)
         result = handler.handle({
-            "expression": r"\sin(x) = 0",
-            "environment": {"solve_domain": "Interval.Ropen(0, 2 * pi)"},
-            "symbols": ["x"],
+            "expression": expr,
+            "environment": {"definitionsv2": defs},
+            "symbols": solve_symbs,
         })
 
-        assert result.symbols == [x]
-        assert result.solution == FiniteSet(0, pi)
+        assert result.symbols == exp_symbs
+        assert result.solution == exp_sol
 
     def test_solve_soe(self):
         x, y, z = symbols("x y z")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pytest.ini_options]
 pythonpath = ["./lmat-cas-client/lmat_cas_client"]
+addopts = "-n auto"
 
 [tool.ruff]
 target-version = "py312"

--- a/src/controllers/commands/SolveCommand.ts
+++ b/src/controllers/commands/SolveCommand.ts
@@ -39,13 +39,11 @@ export class SolveCommand extends LatexMathCommand {
             const symbol_selector = new SolveModeModal(
                 solve_info_result.available_symbols,
                 solve_info_result.required_symbols,
-                lmat_env.solve_domain ?? "",
                 app);
 
             symbol_selector.open();
 
             const config = await symbol_selector.getSolveConfig();
-            lmat_env.solve_domain = config.domain;
 
             symbols = config.symbols;
         } else {

--- a/src/models/cas/LmatEnvironment.ts
+++ b/src/models/cas/LmatEnvironment.ts
@@ -18,8 +18,7 @@ export class LmatEnvironment {
         return new LmatEnvironment(
             parsed_lmat_block.symbols,
             definitions,
-            parsed_lmat_block.units?.system,
-            parsed_lmat_block.solve?.domain
+            parsed_lmat_block.units?.system
         );
     }
 
@@ -98,10 +97,6 @@ export class LmatEnvironment {
          * if left undefined, SI is used as the default system.
          */
         public unit_system: string | undefined = undefined,
-        /**
-         * the domain is a sympy expression, evaluating to the default solution domain of any equation solutions.
-         */
-        public solve_domain: string | undefined = undefined
     ) { }
 
     // regex for extracting the contents of an lmat code block.

--- a/src/tests/messages/SolveMessage.test.ts
+++ b/src/tests/messages/SolveMessage.test.ts
@@ -14,7 +14,7 @@ test('Test Solve Message', async () => {
 
 test('Test Solve Message With Assumptions', async () => {
     const response = response_verifier.verifyResponse<SolveResponse>(await server.send(
-        new SolveMessage(new SolveArgsPayload("x^2 = 4", new LmatEnvironment(undefined, undefined, undefined, "Naturals"), ["x"]))
+        new SolveMessage(new SolveArgsPayload("x^2 = 4", new LmatEnvironment(undefined, ["x \\in \\mathbb{R}_{+}"], undefined), ["x"]))
     ).response);
 
     expect(normLatexStr(response.solution_set)).toMatch(/x\s*=\s*2/g);

--- a/src/views/modals/SolveModeModal.ts
+++ b/src/views/modals/SolveModeModal.ts
@@ -2,14 +2,13 @@ import { App, finishRenderMath, Notice, renderMath, Setting } from "obsidian";
 import { LatexMathSymbol } from "/models/cas/messages/SolveMessage";
 import { BaseModal } from "./BaseModal";
 
-type SolveConfig = { domain: string, symbols: LatexMathSymbol[] };
+type SolveConfig = { symbols: LatexMathSymbol[] };
 
 // The SymbolSelectorModal provides a modal dialog to select a single symbol from a list of symbols.
 // Once opened, the getSelectedSymbolAsync method can be awaited to get the selected symbol.
 export class SolveModeModal extends BaseModal {
     constructor(symbols: LatexMathSymbol[],
         protected equation_count: number,
-        protected domain: string,
         app: App) {
         super(app);
 
@@ -29,15 +28,6 @@ export class SolveModeModal extends BaseModal {
         // setup view
 
         this.setTitle("Solve equations");
-
-        new Setting(this.contentEl)
-            .setName("Solution domain")
-            .addText(text => {
-                text.setValue(this.domain);
-                text.onChange((value) => {
-                    this.domain = value;
-                });
-            });
 
         // create list of selectable symbols.
         const symbols_div = this.contentEl.createDiv("prompt-results");
@@ -86,11 +76,11 @@ export class SolveModeModal extends BaseModal {
         }
 
         this.close();
-        this.solve_config_resolve({ domain: this.domain, symbols: selected_symbols });
+        this.solve_config_resolve({ symbols: selected_symbols });
     }
 
     private symbol_selection: Map<LatexMathSymbol, boolean> = new Map();
 
     private solve_config_promise: Promise<SolveConfig>;
-    private solve_config_resolve: (value: SolveConfig | PromiseLike<SolveConfig>) => void;
+    private solve_config_resolve: (value: SolveConfig | PromiseLike<SolveConfig>) => void = (_) => { };
 }

--- a/src/views/modals/UnitConvertModeModal.ts
+++ b/src/views/modals/UnitConvertModeModal.ts
@@ -46,5 +46,5 @@ export class UnitConvertModeModal extends BaseModal {
     private target_units: string[] = [];
 
     private target_units_promise: Promise<string[]>;
-    private target_units_resolve: (value: string[] | PromiseLike<string[]>) => void;
+    private target_units_resolve: (value: string[] | PromiseLike<string[]>) => void = (_) => { };
 }


### PR DESCRIPTION
minor refactors (still breaking changes) to solve command.
Matrices are now seen as system of equations.
Domain for solveset is now based on the assumptions on the symbol to solve form, instead of solve_domain, which has been completely removed from the lmat environment.